### PR TITLE
Add worker node qa

### DIFF
--- a/.github/workflows/qa-ec2.yml
+++ b/.github/workflows/qa-ec2.yml
@@ -10,13 +10,14 @@ jobs:
   deploy-ec2:
     name: deploy-ec2-e2e
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       AWS_REGION: "us-east-1"
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
       BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+      QA_GITHUB_TOKEN: ${{ secrets.QA_GITHUB_TOKEN }}
       ANSIBLE_HOST_KEY_CHECKING: "false"
     steps:
       - name: Checkout repository
@@ -40,17 +41,31 @@ jobs:
 
       - name: Run Playbook to initialize the EC2 instance
         run: |
-          ansible-playbook -i inventory.txt deploy-ec2.yml
+          ansible-playbook -i deploy/ansible/inventory.txt deploy/ansible/deploy-ec2.yml
 
-      - name: Run Playbook to install prerequisites
+      - name: Run Playbook to install worker node prerequisites
         run: |
           ansible-galaxy install -r requirements.yml
-          ansible-playbook -i inventory.txt deploy-prereqs.yml
+          ansible-playbook -i deploy/ansible/inventory.txt deploy/ansible/deploy-worker-prereqs.yml
 
-      - name: Deploy the bot container
+      - name: Build and deploy the worker image
         run: |
           echo "${ANSIBLE_VAULT_PASSWORD}" > ansible_vault_password_file
-          ansible-playbook -i inventory.txt -e @secrets.enc \
+          ansible-playbook -i deploy/ansible/inventory.txt \
+          -e "qa_github_token=${QA_GITHUB_TOKEN}" \
           --vault-password-file ansible_vault_password_file \
-          -e "github_token=${BOT_GITHUB_TOKEN}" deploy-bot.yml
-          rm -f ansible_vault_password_file
+          deploy/ansible/qa/build-worker/build-worker-img.yml
+
+#      - name: Deploy the bot container
+#        run: |
+#          echo "${ANSIBLE_VAULT_PASSWORD}" > ansible_vault_password_file
+#          ansible-playbook -i deploy/ansible/inventory.txt -e @secrets.enc \
+#          --vault-password-file ansible_vault_password_file \
+#          -e "github_token=${BOT_GITHUB_TOKEN}" deploy/ansible/deploy-bot.yml
+#          rm -f ansible_vault_password_file
+
+      - name: Terminate EC2 Instances
+        if: always()
+        run: |
+          ansible-playbook deploy/ansible/qa/terminate-qa/terminate-qa.yml \
+          --private-key ~/.ssh/id_rsa

--- a/deploy/ansible/ec2/defaults/main.yml
+++ b/deploy/ansible/ec2/defaults/main.yml
@@ -3,13 +3,13 @@ aws_region: us-east-1                 # AWS region
 aws_image_id: ami-0746fc234df9c1ee0   # Fedora39
 aws_key_name: instruct-bot            # the key pair on your aws account to use
 aws_instance_type: p3.2xlarge         # low tier GPU 1x v100
-aws_nodetype_tag: instruct-bot        # Unique tag identifier for ec2 instances
+aws_nodetype_tag: instruct-bot-qa     # Unique tag identifier for ec2 instances
 ansible_user: fedora                  # this is the default user ID for your AMI image. Example, AWS AMI is ec2-user etc
 security_group_description: "Instruct Bot SG"
 inventory_location: inventory.txt     # leaving this as is will use the inventory.txt file in the base directory
 
 ### VPC Details ###
-secgroup_name: instruct-bot-sg   # the security group name can be an existing group or else it will be created by the playbook
+secgroup_name: instruct-bot-sg        # the security group name can be an existing group or else it will be created by the playbook
 node_count: 1                         # the number of nodes to be deployed
 vpc_id: vpc-27b7165a                  # VPC id
-aws_subnet: subnet-c8db48e9      # VPC subnet id
+aws_subnet: subnet-c8db48e9           # VPC subnet id

--- a/deploy/ansible/nvidia-container-toolkit/tasks/main.yml
+++ b/deploy/ansible/nvidia-container-toolkit/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Reboot
   ansible.builtin.reboot:
-    reboot_timeout: 300
+    reboot_timeout: 500
     msg: "Rebooting to load NVIDIA drivers"
   when: nvidia_install_kmod.changed or nvidia_install_cuda.changed
 

--- a/deploy/ansible/qa/build-worker/build-worker-img.yml
+++ b/deploy/ansible/qa/build-worker/build-worker-img.yml
@@ -1,0 +1,5 @@
+- name: QA Build Worker Image
+  hosts: labNodes
+  roles:
+    - role: worker
+      become: true

--- a/deploy/ansible/qa/build-worker/worker/defaults/main.yml
+++ b/deploy/ansible/qa/build-worker/worker/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+qa_github_uid: nerdalert
+qa_github_token: defaultTokenValue

--- a/deploy/ansible/qa/build-worker/worker/tasks/main.yml
+++ b/deploy/ansible/qa/build-worker/worker/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Build Docker image
+  community.docker.docker_image:
+    build:
+      path: "./worker"
+      args:
+        GITHUB_USER: "{{ qa_github_uid }}"
+        GITHUB_TOKEN: "{{ qa_github_token }}"
+    name: "ghcr.io/redhat-et/instruct-lab-bot/instruct-lab-serve"
+    tag: "main"
+    source: build
+
+- name: List container images
+  ansible.builtin.command:
+    cmd: docker image ls
+  register: ls_images
+  changed_when: false
+
+- name: Print the output of images listing
+  ansible.builtin.debug:
+    var: ls_images.stdout_lines
+
+- name: Start the worker
+  ansible.builtin.command:
+    cmd: docker run --gpus all -it --entrypoint /bin/bash -d -v /home/fedora/instructlab:/data ghcr.io/redhat-et/instruct-lab-bot/instruct-lab-serve:main
+  changed_when: true
+
+- name: List all containers
+  ansible.builtin.command:
+    cmd: docker ps -a
+  register: ps_output
+  changed_when: false
+
+- name: Pause for 30 seconds before listing
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: Print the output of the container listing
+  ansible.builtin.debug:
+    var: ps_output.stdout_lines

--- a/deploy/ansible/qa/terminate-qa/terminate-qa.yml
+++ b/deploy/ansible/qa/terminate-qa/terminate-qa.yml
@@ -1,0 +1,5 @@
+# Terminate QA EC2 Instances
+- name: Terminate QA instances matching the defined EC2 tags
+  hosts: localhost
+  roles:
+    - role: terminate

--- a/deploy/ansible/qa/terminate-qa/terminate/defaults/main.yml
+++ b/deploy/ansible/qa/terminate-qa/terminate/defaults/main.yml
@@ -1,0 +1,1 @@
+aws_nodetype_tag: instruct-bot-qa     # Unique qa tag identifier for ec2 instances

--- a/deploy/ansible/qa/terminate-qa/terminate/tasks/main.yml
+++ b/deploy/ansible/qa/terminate-qa/terminate/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for terminate-ec2
+- name: Terminate all running ec2 instances in the region us-east-1 with the nodeType tag "{{ aws_nodetype_tag }}"
+  become: false
+  amazon.aws.ec2_instance:
+    state: absent
+    filters:
+      "tag:NodeType": "{{ aws_nodetype_tag }}"
+      instance-state-name: running


### PR DESCRIPTION
- Building the worker image until we get the image trimmed down.
- Adjusted the reboot timer in the toolkit role as the ec2 v100 nodes are super slow to bounce