### PR TITLE
Add docker-compose for bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,7 @@ png-lint: ## Lint the png files from excalidraw
 			exit 1 ; \
 		fi \
 	done
+
+bot-image: bot/Dockerfile ## Build docker image for the bot
+	$(ECHO_PREFIX) printf "  %-12s bot/Dockerfile\n" "[DOCKER]"
+	$(CMD_PREFIX) docker build -f bot/Dockerfile -t quay.io/instruct-lab-bot/bot:latest .

--- a/docker-compose.bot.yml
+++ b/docker-compose.bot.yml
@@ -1,0 +1,22 @@
+version: "3.4"
+
+services:
+  redis:
+    container_name: redis
+    image: redis:latest
+    ports:
+      - 6379:6379
+
+  bot:
+    container_name: bot
+    image: quay.io/instruct-lab-bot/bot:latest
+    depends_on:
+      - redis
+    ports:
+      - 8000:3000
+    environment:
+      - APP_ID=${APP_ID}
+      - LOG_LEVEL=${LOG_LEVEL}
+      - PRIVATE_KEY=${PRIVATE_KEY}
+      - REDIS_URL=redis://redis:6379
+      - WEBHOOK_PROXY_URL=${WEBHOOK_PROXY_URL}


### PR DESCRIPTION
Add docker-compose config to bring up the bot + redis. I still need
to add a worker container.

You need an `.env` file to populate the expected variables.

You run `make bot-iamge` to build a local image for the bot that will
be used.

`docker compose -f docker-compose.bot.yml up`

part of #59

Signed-off-by: Russell Bryant <rbryant@redhat.com>