### PR TITLE
bot: Remove comment when pull request gets opened

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -9,7 +9,7 @@ dotenv.config();
 const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
 
 export default (app: Probot) => {
-  app.on("pull_request.opened", async (context) => {
+  /*app.on("pull_request.opened", async (context) => {
     const issueComment = context.issue({
       body:
         `Beep, boop 🤖  Hi, I'm instruct-lab-bot and I'm going to help you` +
@@ -21,7 +21,7 @@ export default (app: Probot) => {
         ` and you can proceed with the review.`,
     });
     await context.octokit.issues.createComment(issueComment);
-  });
+  });*/
   app.on("issue_comment.created", async (context) => {
     const client = await createClient({
       url: REDIS_URL,


### PR DESCRIPTION
We normally post a comment when a PR is first posted, instructing
users on how to make use of the bot. While we're in a period of
migration and getting things working on the main taxonomy repo, turn
this off so it doesn't draw attention from people that shouldn't be
bothered by it yet.

Signed-off-by: Russell Bryant <rbryant@redhat.com>