### PR TITLE
deploy: Revert to using redis-ip from the vault

### DIFF
--- a/deploy/ansible/bot/tasks/main.yml
+++ b/deploy/ansible/bot/tasks/main.yml
@@ -21,5 +21,5 @@
       APP_ID: "{{ app_id }}"
       PRIVATE_KEY: "{{ private_key }}"
       WEBHOOK_SECRET: "{{ webhook_secret }}"
-      REDIS_URL: "redis://{{ redis_info.container.NetworkSettings.IPAddress }}:6379"
+      REDIS_URL: "redis://{{ redis_ip }}:6379"
       WEBHOOK_PROXY_URL: "{{ webhook_proxy_url }}"

--- a/deploy/ansible/grafana/tasks/main.yml
+++ b/deploy/ansible/grafana/tasks/main.yml
@@ -15,7 +15,7 @@
     path: /home/fedora/grafana/provisioning/datasources/datasource.yaml
     backup: true
     regexp: 'redis://redis:6379'
-    replace: 'redis://{{ redis_info.container.NetworkSettings.IPAddress }}:6379'
+    replace: 'redis://{{ redis_ip }}:6379'
 
 - name: Start Grafana container
   community.docker.docker_container:


### PR DESCRIPTION
This reflects how redis is currently deployed in production, which is
not the containerized version. The current state of the bot and
grafana playbooks won't work against prod. This change will make it
work.

Signed-off-by: Russell Bryant <rbryant@redhat.com>