### PR TITLE
Free disk space on worker runner before building

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -54,6 +54,21 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          sudo apt install aptitude -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+
       - name: Check out the repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
- Frees up about 15-20G since we are bumping on the runner capacity as opposed to ghcr (for meow).