### PR TITLE
Update the compose file to the redis service name.

### DIFF
--- a/gobot/config.yaml.sample
+++ b/gobot/config.yaml.sample
@@ -3,7 +3,7 @@ server:
   port: 8080
 
 app_configuration:
-  redis_hostport: "localhost:6379"
+  redis_hostport: "redis:6379"
   # Get an ID from https://smee.io/new
   # Optional. If blank, the app will not use a webhook proxy.
   webhook_proxy_url: "https://smee.io/your-smee-id"


### PR DESCRIPTION
Resolves the error:

```
ERROR	bot/bot.go:105	Redis Client Error: dial tcp [::1]:6379: connect: connection refused
bot     | github.com/instruct-lab/instruct-lab-bot/gobot/bot.receiveResults
```