### PR TITLE
Adapt for `lab` rename to `ilab`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Our goal is to implement a GitHub bot that will:
 
 ### Current Status
 
-The current iteration is focused on automating the `lab generate` portion of the workflow. The following diagram shows the architecture of the bot and its supporting infrastructure. It supports scaling a pool of workers to run `lab generate` jobs. The workers can be located anywhere and will be connect to Redis over a private mesh network managed by [Nexodus](https://nexodus.io).
+The current iteration is focused on automating the `ilab generate` portion of the workflow. The following diagram shows the architecture of the bot and its supporting infrastructure. It supports scaling a pool of workers to run `ilab generate` jobs. The workers can be located anywhere and will be connect to Redis over a private mesh network managed by [Nexodus](https://nexodus.io).
 
 [![Instruct Lab Bot Architecture](./docs/bot-arch.png)](./docs/bot-arch.png)
 
@@ -30,7 +30,7 @@ The current GitHub workflow in a PR is:
 
 1. PR is opened by the Contributor.
 2. User runs `@instruct-lab-bot generate` in a comment on the PR.
-3. Bot generates data using `lab generate` and stores it in an object store (S3).
+3. Bot generates data using `ilab generate` and stores it in an object store (S3).
 4. Bot replies: "Here is the generated data ..."
 
 ## Components

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -182,7 +182,7 @@ Restart=always
 RestartSec=1
 User=fedora
 Group=fedora
-ExecStart=lab serve
+ExecStart=ilab serve
 WorkingDirectory=/home/fedora/instruct-lab-bot
 
 [Install]
@@ -196,7 +196,7 @@ EOF
 
 install_lab() {
     cd "${WORK_DIR}" || (echo "Failed to change to work directory: ${WORK_DIR}" && exit 1)
-    if ! command_exists "lab"; then
+    if ! command_exists "ilab"; then
         sudo pip install "git+https://instruct-lab-bot:${GITHUB_TOKEN}@github.com/instruct-lab/cli#egg=cli"
         if [ "${GPU_TYPE}" = "cuda" ]; then
             CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
@@ -206,9 +206,9 @@ install_lab() {
         fi
     fi
     if [ ! -f config.yaml ]; then
-        lab init --non-interactive
+        ilab init --non-interactive
     fi
-    lab download
+    ilab download
     config_lab_systemd
 }
 

--- a/worker/Containerfile
+++ b/worker/Containerfile
@@ -53,5 +53,5 @@ COPY --from=builder /app/instruct-lab-bot/worker/instruct-lab-bot-worker /usr/lo
 
 VOLUME [ "/data" ]
 WORKDIR /data
-ENTRYPOINT [ "lab", "serve" ]
+ENTRYPOINT [ "ilab", "serve" ]
 CMD ["/bin/bash"]

--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -260,9 +260,9 @@ func processJob(ctx context.Context, conn redis.Conn, svc *s3.Client, logger *za
 	sugar = sugar.With("out_dir", outputDir)
 	_ = os.MkdirAll(outputDir, 0755)
 
-	lab := "lab"
+	lab := "ilab"
 	if VenvDir != "" {
-		lab = path.Join(VenvDir, "bin", "lab")
+		lab = path.Join(VenvDir, "bin", "ilab")
 	}
 
 	cmd := exec.CommandContext(ctx, lab, "generate", "--num-instructions", fmt.Sprintf("%d", NumInstructions), "--output-dir", outputDir)


### PR DESCRIPTION
I tried to find every spot we called `lab` and fix it to be `ilab` to
match the latest code from the cli repo.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
