### PR TITLE
Add a label access control to generate requests #118

### DIFF
--- a/gobot/bot/bot.go
+++ b/gobot/bot/bot.go
@@ -48,6 +48,7 @@ func Run(zLogger *zap.Logger) error {
 		ClientCreator: cc,
 		Logger:        logger,
 		RedisHostPort: config.AppConfig.RedisHostPort,
+		RequiredLabel: config.AppConfig.RequiredLabel,
 	}
 
 	webhookHandler := githubapp.NewDefaultEventDispatcher(config.Github, prCommentHandler)

--- a/gobot/config/config.go
+++ b/gobot/config/config.go
@@ -9,9 +9,8 @@ import (
 )
 
 type Config struct {
-	Server HTTPConfig       `yaml:"server"`
-	Github githubapp.Config `yaml:"github"`
-
+	Server    HTTPConfig          `yaml:"server"`
+	Github    githubapp.Config    `yaml:"github"`
 	AppConfig MyApplicationConfig `yaml:"app_configuration"`
 }
 
@@ -23,6 +22,7 @@ type HTTPConfig struct {
 type MyApplicationConfig struct {
 	RedisHostPort   string `yaml:"redis_hostport"`
 	WebhookProxyURL string `yaml:"webhook_proxy_url"`
+	RequiredLabel   string `yaml:"required_label,omitempty"`
 }
 
 func ReadConfig(path string) (*Config, error) {

--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -17,6 +18,7 @@ type PRCommentHandler struct {
 	githubapp.ClientCreator
 	Logger        *zap.SugaredLogger
 	RedisHostPort string
+	RequiredLabel string
 }
 
 type PRComment struct {
@@ -97,6 +99,34 @@ func (h *PRCommentHandler) reportError(ctx context.Context, client *github.Clien
 func (h *PRCommentHandler) generateCommand(ctx context.Context, client *github.Client, prComment *PRComment) error {
 	h.Logger.Infof("Generate command received on %s/%s#%d by %s",
 		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
+
+	// Check if the required label is present if a required label is in the config file
+	if h.RequiredLabel != "" {
+		pr, _, err := client.PullRequests.Get(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum)
+		if err != nil {
+			return err
+		}
+
+		labelFound := false
+		for _, label := range pr.Labels {
+			if label.GetName() == h.RequiredLabel {
+				labelFound = true
+				break
+			}
+		}
+
+		if !labelFound {
+			h.Logger.Infof("Required label %s not found on PR %s/%s#%d by %s",
+				h.RequiredLabel, prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
+			missingLabelComment := fmt.Sprintf("Beep, boop 🤖: To proceed, the pull request must have the '%s' label.", h.RequiredLabel)
+			botComment := github.IssueComment{Body: &missingLabelComment}
+			_, _, err = client.Issues.CreateComment(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum, &botComment)
+			if err != nil {
+				h.Logger.Errorf("Failed to comment on pull request about missing label: %v", err)
+			}
+			return nil
+		}
+	}
 
 	r := redis.NewClient(&redis.Options{
 		Addr:     h.RedisHostPort,


### PR DESCRIPTION
- Adds the option for a label check to generate.
- The label is defined in the config file, if there is no label definition, the check is skipped.
- If a generate is requested without a required label, a message is sent back to the PR rejecting the generate with the missing label name.
