### PR TITLE
Remove pre-signed URLs for public URLs

### DIFF
--- a/gobot/bot/bot.go
+++ b/gobot/bot/bot.go
@@ -162,8 +162,7 @@ func receiveResults(config *config.Config, logger *zap.SugaredLogger, cc githuba
 		issueComment := github.IssueComment{
 			Body: github.String(
 				"Beep, boop 🤖  The test data has been generated!\n\n" +
-					"Find your results [here](" + s3Url + ").\n\n" +
-					"*This URL expires in 7 days.*"),
+					"Find your results [here](" + s3Url + ")."),
 		}
 		client, err := cc.NewInstallationClient(int64(installIDInt))
 		if err != nil {


### PR DESCRIPTION
- This alleviates the max 7-days restriction.
- Having pre-signed wasn't providing any benefits since we weren't doing any fine grained access control or tracking user access.
- Any other alternatives require tracking and generating our own JWTs which wouldn't make sense for the current requirements. We can always implement bucket wide policy if that becomes a need.
- Before merging this, the bucket needs a public policy applied provided in this PRs comments.