### PR TITLE
Hold: Add support for endpoint-url for ilab generate

### DIFF
--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -92,7 +92,7 @@ func (h *PRCommentHandler) reportError(ctx context.Context, client *github.Clien
 	h.Logger.Errorf("Error processing command on %s/%s#%d by %s: %v",
 		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author, err)
 
-	msg := "Beep, boop 🤖  Sorry, An error has occurred."
+	msg := fmt.Sprintf("Beep, boop 🤖  Sorry, An error has occurred : %v", err)
 	botComment := github.IssueComment{
 		Body: &msg,
 	}

--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -31,6 +31,7 @@ import (
 var (
 	WorkDir         string
 	VenvDir         string
+	EndpointURL     string
 	NumInstructions int
 	Origin          string
 	GithubToken     string
@@ -46,6 +47,7 @@ const (
 func init() {
 	generateCmd.Flags().StringVarP(&WorkDir, "work-dir", "w", "", "Directory to work in")
 	generateCmd.Flags().StringVarP(&VenvDir, "venv-dir", "v", "", "The virtual environment directory")
+	generateCmd.Flags().StringVarP(&EndpointURL, "endpoint-url", "e", "http://localhost:8000/v1", "Endpoint hosting the model API. Default, it assumes the model is served locally.")
 	generateCmd.Flags().IntVarP(&NumInstructions, "num-instructions", "n", 10, "The number of instructions to generate")
 	generateCmd.Flags().StringVarP(&Origin, "origin", "o", "origin", "The origin to fetch from")
 	generateCmd.Flags().StringVarP(&GithubToken, "github-token", "g", "", "The GitHub token to use for authentication")
@@ -403,7 +405,7 @@ func processJob(ctx context.Context, conn redis.Conn, svc *s3.Client, logger *za
 	var cmd *exec.Cmd
 	switch jobType {
 	case "generate":
-		cmd = exec.CommandContext(ctx, lab, "generate", "--num-instructions", fmt.Sprintf("%d", NumInstructions), "--output-dir", outputDir)
+		cmd = exec.CommandContext(ctx, lab, "generate", "--num-instructions", fmt.Sprintf("%d", NumInstructions), "--output-dir", outputDir, "--endpoint-url", EndpointURL)
 		if WorkDir != "" {
 			cmd.Dir = WorkDir
 		}

--- a/worker/main.go
+++ b/worker/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	// Initlaize global logger
+	// Initialize global logger
 	logLevel := zap.InfoLevel
 	loggerConfig := zap.Config{
 		Level:            zap.NewAtomicLevelAt(logLevel),


### PR DESCRIPTION
endpoint-url option is exposed for the worker/generate. User can use this option to configure worker nodes to run generate against specific endpoints hosting the model.  Underneath both the options sets the --endpoint-url for `ilab generate` command. 

Fixes #116 