### PR TITLE
Make the bot account variable

### DIFF
--- a/gobot/bot/bot.go
+++ b/gobot/bot/bot.go
@@ -49,6 +49,7 @@ func Run(zLogger *zap.Logger) error {
 		Logger:        logger,
 		RedisHostPort: config.AppConfig.RedisHostPort,
 		RequiredLabel: config.AppConfig.RequiredLabel,
+		BotUsername:   config.GetBotUsername(),
 	}
 
 	webhookHandler := githubapp.NewDefaultEventDispatcher(config.Github, prCommentHandler)

--- a/gobot/config.yaml.sample
+++ b/gobot/config.yaml.sample
@@ -12,6 +12,8 @@ app_configuration:
   # bot commands will always be allowed by anyone able to comment
   # on PRs.
   required_label: "triage-ok-to-test"
+  # Optional. If left commented, the default bot account is @instruct-lab-bot
+  # bot_username: "@instruct-lab-bot"
 
 github:
   v3_api_url: "https://api.github.com/"

--- a/gobot/config/config.go
+++ b/gobot/config/config.go
@@ -23,6 +23,7 @@ type MyApplicationConfig struct {
 	RedisHostPort   string `yaml:"redis_hostport"`
 	WebhookProxyURL string `yaml:"webhook_proxy_url"`
 	RequiredLabel   string `yaml:"required_label,omitempty"`
+	BotUsername     string `yaml:"bot_username,omitempty"`
 }
 
 func ReadConfig(path string) (*Config, error) {
@@ -38,4 +39,11 @@ func ReadConfig(path string) (*Config, error) {
 	}
 
 	return &c, nil
+}
+
+func (c *Config) GetBotUsername() string {
+	if c.AppConfig.BotUsername == "" {
+		return "@instruct-lab-bot"
+	}
+	return c.AppConfig.BotUsername
 }

--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -19,6 +19,7 @@ type PRCommentHandler struct {
 	Logger        *zap.SugaredLogger
 	RedisHostPort string
 	RequiredLabel string
+	BotUsername   string
 }
 
 type PRComment struct {
@@ -67,7 +68,7 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 	if len(words) < 2 {
 		return nil
 	}
-	if words[0] != "@instruct-lab-bot" {
+	if words[0] != h.BotUsername {
 		return nil
 	}
 	switch words[1] {


### PR DESCRIPTION
- Add a field in the bot config to pass a bot account.
- The default account if no bot_username configuration is provided is @instruct-lab-bot.
- #154 