### PR TITLE
Make end-to-end deployment of bot stack on aws instance bit more convinient.

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -31,10 +31,22 @@ aws_access_key_id=<YOUR_AWS_ACCESS_KEY>
 aws_secret_access_key=<YOUR_SECRET_ACCESS_KEY>
 ```
 
-Once your aws credentials are set up, you can run the following command to deploy the EC2 instance:
+Once your aws credentials are set up, you can run the following command to deploy the required EC2 instance.
+
+## Deploy EC2 bot node for InstructLab
+
+It creates t2x.large instance that can be used to deploy the bot stack (bot, redis and grafana)
 
 ```console
-ansible-playbook ./deploy-ec2.yml
+ansible-playbook ./deploy-ec2-bot.yml
+```
+
+## Deploy EC2 worker node for InstructLab
+
+It creates g4dn.xlarge instance that can be used to deploy the worker stack.
+
+```console
+ansible-playbook ./deploy-ec2-worker.yml
 ```
 
 ## Install Pre-requisites

--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -9,4 +9,4 @@ stdout_callback = yaml
 # defaults to the base directory in the project
 inventory = inventory.txt
 # create .pem private_key_file and provide location
-private_key_file = ./lab-bot.pem
+private_key_file = ./instruct-bot.pem

--- a/deploy/ansible/deploy-bot-stack.yml
+++ b/deploy/ansible/deploy-bot-stack.yml
@@ -1,9 +1,11 @@
 - name: Deploy bot stack (Bot app, Redis, Grafana on EC2 node)
-  hosts: labNodes
+  hosts: botNode
   roles:
     - role: geerlingguy.docker
       become: true
     - role: packages
+      become: true
+    - role: nexodus
       become: true
     - role: redis-docker
       become: true
@@ -11,3 +13,5 @@
       become: true
     - role: gobot
       become: true
+  vars_files:
+    - vars.yml

--- a/deploy/ansible/deploy-ec2-bot.yml
+++ b/deploy/ansible/deploy-ec2-bot.yml
@@ -1,0 +1,10 @@
+- name: Deploy EC2 Nodes
+  hosts: localhost
+  roles:
+    - role: ec2
+      vars:
+        ec2_aws_instance_type: t2.xlarge
+        ec2_aws_nodetype_tag: "instruct-lab-bot-node"
+        ec2_aws_key_path: "./instruct-bot.pem"
+        ec2_count: 1
+        ec2_wait: true

--- a/deploy/ansible/deploy-ec2-worker.yml
+++ b/deploy/ansible/deploy-ec2-worker.yml
@@ -1,0 +1,10 @@
+- name: Deploy EC2 Nodes
+  hosts: localhost
+  roles:
+    - role: ec2
+      vars:
+        ec2_aws_instance_type: g4dn.xlarge
+        ec2_aws_nodetype_tag: "instruct-lab-worker-node"
+        ec2_aws_key_path: "./instruct-bot.pem"
+        ec2_count: 1
+        ec2_wait: true

--- a/deploy/ansible/deploy-ec2.yml
+++ b/deploy/ansible/deploy-ec2.yml
@@ -1,4 +1,0 @@
-- name: Deploy EC2 Nodes
-  hosts: localhost
-  roles:
-    - role: ec2

--- a/deploy/ansible/ec2/tasks/main.yml
+++ b/deploy/ansible/ec2/tasks/main.yml
@@ -61,6 +61,15 @@
     regexp: "labNodes"
     line: "[labNodes]\n{{ item.0['instances'][0]['public_ip_address'] }} ansible_ssh_user=fedora ansible_ssh_private_key_file=~/.ssh/id_rsa"
   loop: "{{ ec2_jobs_with_index }}"
+  when: aws_instance_type == "g4dn.xlarge"
+
+- name: Updating the node's public ip in inventory
+  ansible.builtin.lineinfile:
+    path: "{{ inventory_location }}"
+    regexp: "botNode"
+    line: "[botNode]\n{{ item.0['instances'][0]['public_ip_address'] }} ansible_ssh_user=fedora ansible_ssh_private_key_file={{ aws_key_path }}"
+  loop: "{{ ec2_jobs_with_index }}"
+  when: aws_instance_type != "g4dn.xlarge"
 
 - name: Parse the first host from the inventory
   ansible.builtin.set_fact:

--- a/deploy/ansible/inventory
+++ b/deploy/ansible/inventory
@@ -1,2 +1,0 @@
-[labNodes]
-instruct-lab-bot ansible_ssh_user=fedora

--- a/deploy/ansible/inventory.txt
+++ b/deploy/ansible/inventory.txt
@@ -1,1 +1,2 @@
+[botNode]
 [labNodes]

--- a/deploy/ansible/redis-docker/tasks/main.yml
+++ b/deploy/ansible/redis-docker/tasks/main.yml
@@ -22,6 +22,12 @@
       - "{{ nexodus_tunnelip_v4.stdout }}:{{ redis_port }}:6379"
   register: redis_container
 
+- name: Set Redis binding IP address
+  ansible.builtin.set_fact:
+    redis_ip: "{{ nexodus_tunnelip_v4.stdout }}"
+    cacheable: true
+  when: redis_ip is not defined
+
 - name: Wait until Redis is available
   ansible.builtin.wait_for:
     host: '{{ nexodus_tunnelip_v4.stdout }}'

--- a/deploy/ansible/vars.yml
+++ b/deploy/ansible/vars.yml
@@ -1,0 +1,10 @@
+## Global Variables
+nexd_args: "--reg-key <nexodus-reg-key-url>"
+redis_port: 6379
+github_token:
+webhook_proxy_url: "<smee-proxy-url>"
+app_id:
+webhook_secret: ""
+private_key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      -----END RSA PRIVATE KEY-----


### PR DESCRIPTION

- Added deploy-ec2-bot playbook to spwan normal ec2 instance for bot stack.

- Define global variables in vars.yaml, so dev doesn't need to dig into each rule to set specific vars.

- Updated dev-end.md with instruction how dev can deploy the bot stack in aws for testing purposes.