### PR TITLE
Restore bot introduction on new pull requests

### DIFF
--- a/gobot/bot/bot.go
+++ b/gobot/bot/bot.go
@@ -52,7 +52,14 @@ func Run(zLogger *zap.Logger) error {
 		BotUsername:   config.GetBotUsername(),
 	}
 
-	webhookHandler := githubapp.NewDefaultEventDispatcher(config.Github, prCommentHandler)
+	prHandler := &handlers.PullRequestHandler{
+		ClientCreator: cc,
+		Logger:        logger,
+		RequiredLabel: config.AppConfig.RequiredLabel,
+		BotUsername:   config.GetBotUsername(),
+	}
+
+	webhookHandler := githubapp.NewDefaultEventDispatcher(config.Github, prCommentHandler, prHandler)
 
 	http.Handle(githubapp.DefaultWebhookRoute, webhookHandler)
 

--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -32,6 +32,7 @@ type PRComment struct {
 }
 
 func (h *PRCommentHandler) Handles() []string {
+	// PR comments come in as issue comments, not an independent event type.
 	return []string{"issue_comment"}
 }
 

--- a/gobot/handlers/pull_request.go
+++ b/gobot/handlers/pull_request.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-github/v60/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+type PullRequestHandler struct {
+	githubapp.ClientCreator
+	Logger        *zap.SugaredLogger
+	RequiredLabel string
+	BotUsername   string
+}
+
+func (h *PullRequestHandler) Handles() []string {
+	return []string{"pull_request"}
+}
+
+func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.PullRequestEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse issue comment event payload")
+	}
+
+	if event.GetAction() != "opened" {
+		return nil
+	}
+
+	installID := githubapp.GetInstallationIDFromEvent(&event)
+	repo := event.GetRepo()
+	repoOwner := repo.GetOwner().GetLogin()
+	repoName := repo.GetName()
+	prNum := event.GetPullRequest().GetNumber()
+
+	client, err := h.NewInstallationClient(installID)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf("Beep, boop 🤖 Hi, I'm %s and I'm going to help you"+
+		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
+	if h.RequiredLabel != "" {
+		msg += fmt.Sprintf("> [!NOTE]\n"+
+			"> Before you are able to use the bot's commands, it must be triaged "+
+			"and have the `%s` label applied to it.\n\n", h.RequiredLabel)
+	}
+	msg += fmt.Sprintf("I support the following commands:\n\n"+
+		"* `%s precheck` -- Check existing model behavior using the questions in this proposed change.\n"+
+		"* `%s generate` -- Generate a sample of synthetic data.\n",
+		h.BotUsername, h.BotUsername)
+	botComment := github.IssueComment{
+		Body: &msg,
+	}
+
+	if _, _, err := client.Issues.CreateComment(ctx, repoOwner, repoName, prNum, &botComment); err != nil {
+		h.Logger.Error("Failed to comment on pull request: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The original bot commented on PRs as soon as they came in to introduce
the bot. We turned this off while doing more development and testing
against the main taxonomy repo, but I think we're ready to turn this
back on and let everyone use it who wants to.

The introduction lists the commands, as well as the required label if
one has been configured.

Closes #82

Signed-off-by: Russell Bryant <rbryant@redhat.com>
