### PR TITLE
Add redis pooling and worker refactor

### DIFF
--- a/gobot/bot/bot.go
+++ b/gobot/bot/bot.go
@@ -162,10 +162,12 @@ func receiveResults(config *config.Config, logger *zap.SugaredLogger, cc githuba
 			continue
 		}
 
+		logger.Infof("Processing result for %s/%s#%s, job ID: %s", repoOwner, repoName, prNumber, result)
+
 		// check for errors prior to checking for an S3 url and models since that will not get produced on a failure
 		prErrors, _ := r.Get("jobs:" + result + ":errors").Result()
 		if prErrors != "" {
-			errCommentBody := fmt.Sprintf("Beep, boop 🤖 an error occurred while processing your request, please review the following log:\n```\n%s\n```", prErrors)
+			errCommentBody := fmt.Sprintf("Beep, boop 🤖 an error occurred while processing your request, please review the following log for job id %s :\n```\n%s\n```", result, prErrors)
 			if err := PostComment(ctx, cc, logger, installIDInt, repoOwner, repoName, prNumInt, errCommentBody); err != nil {
 				logger.Errorf("Failed to send issue comment: %v", err)
 			}
@@ -187,7 +189,7 @@ func receiveResults(config *config.Config, logger *zap.SugaredLogger, cc githuba
 		}
 
 		// Add the model name only if it's not empty
-		commentBody := "Beep, boop 🤖  The test data has been generated"
+		commentBody := fmt.Sprintf("Beep, boop 🤖  The test data has been generated for job ID: %s", result)
 		if modelName != "" {
 			commentBody += " " + modelName
 		}

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,2 +1,3 @@
 worker
 instruct-lab-worker.yaml
+profile.cov

--- a/worker/cmd/generate_test.go
+++ b/worker/cmd/generate_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestGenerateIndexHTML(t *testing.T) {
@@ -142,12 +143,14 @@ func TestFetchModelName(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	modelName, err := fetchModelName(context.Background(), mockServer.URL, false)
+	w := NewJobProcessor(context.Background(), nil, nil, zap.NewExample().Sugar(), "", mockServer.URL)
+
+	modelName, err := w.fetchModelName(false)
 	assert.NoError(t, err, "fetchModelName should not return an error")
 	expectedModelName := "Mixtral-8x7B-Instruct-v0.1"
 	assert.Equal(t, expectedModelName, modelName, "The model name should be extracted correctly")
 
-	modelName, err = fetchModelName(context.Background(), mockServer.URL, true)
+	modelName, err = w.fetchModelName(true)
 	assert.NoError(t, err, "fetchModelName should not return an error")
 	expectedModelName = "/shared_model_storage/transformers_cache/models--mistralai--Mixtral-8x7B-Instruct-v0.1/snapshots/5c79a376139be989ef1838f360bf4f1f256d7aec"
 	assert.Equal(t, expectedModelName, modelName, "The model name should be extracted correctly")
@@ -189,7 +192,9 @@ func TestFetchModelNameWithInvalidObject(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	modelName, err := fetchModelName(context.Background(), mockServer.URL, false)
+	w := NewJobProcessor(context.Background(), nil, nil, zap.NewExample().Sugar(), "", mockServer.URL)
+
+	modelName, err := w.fetchModelName(false)
 
 	// Verify that an error was returned due to the invalid "object" field
 	assert.Error(t, err, "fetchModelName should return an error for invalid object field")


### PR DESCRIPTION
- Added a redis pool to resolve #165
- Some refactoring to create an instance of a new worker struct for each new job.
- Added job ID to results for better debugability and tracking.
- Added a precheck error reporting. One thing of note is if no yaml
files were submitted, chat would run without errors resulting in
an empty report. This checks if no yaml files are in the diff
and exits the runPrecheck() method early to avoid unnecessary 
processing since precheck could be a default action on PRs. It
also avoids an empty report.

