### PR TITLE
Drop compose in favor of podman play

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,4 +20,13 @@ services:
     image: ghcr.io/instruct-lab/instruct-lab-bot/instruct-lab-serve:main
     depends_on:
       - redis
-    command: ["/instruct-lab-bot-worker", "--test", "--redis", "redis:6379", "generate", "-g", ""]
+    command:
+      [
+        "/instruct-lab-bot-worker",
+        "--test",
+        "--redis",
+        "redis:6379",
+        "generate",
+        "-g",
+        "",
+      ]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,186 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+data:
+  password: YOUR_GITHUB_TOKEN
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bot-config
+  labels:
+    app.kubernetes.io/name: bot
+    app.kubernetes.io/component: configuration
+    app.kubernetes.io/part-of: instruct-lab-bot
+data:
+  config.yaml: |
+    server:
+      address: "127.0.0.1"
+      port: 8080
+
+    app_configuration:
+      redis_hostport: "redis:6379"
+      # Get an ID from https://smee.io/new
+      # Optional. If blank, the app will not use a webhook proxy.
+      webhook_proxy_url: "https://smee.io/your-smee-id"
+      # Specify a label that must be present on a pull request before
+      # bot commands are allowed to execute. If none is specified,
+      # bot commands will always be allowed by anyone able to comment
+      # on PRs.
+      required_label: "triage-ok-to-test"
+      # Optional. If left commented, the default bot account is @instruct-lab-bot
+      # bot_username: "@instruct-lab-bot"
+
+    github:
+      v3_api_url: "https://api.github.com/"
+      app:
+        integration_id: 0
+        webhook_secret: "your-app-webhook-secret-here"
+        private_key: |
+          your-app-private-key-content-here
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: instruct-lab-bot
+  name: redis
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: instruct-lab-bot
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: instruct-lab-bot
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/component: queue
+      app.kubernetes.io/part-of: instruct-lab-bot
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: queue
+        app.kubernetes.io/part-of: instruct-lab-bot
+    spec:
+      containers:
+        - image: redis:latest
+          name: redis
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      restartPolicy: Always
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: bot
+    app.kubernetes.io/component: bot
+    app.kubernetes.io/part-of: instruct-lab-bot
+  name: bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bot
+      app.kubernetes.io/component: bot
+      app.kubernetes.io/part-of: instruct-lab-bot
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bot
+        app.kubernetes.io/component: bot
+        app.kubernetes.io/part-of: instruct-lab-bot
+    spec:
+      containers:
+        - image: ghcr.io/instruct-lab/instruct-lab-bot/instruct-lab-gobot:main
+          name: bot
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /etc/instruct-lab-bot
+              name: config
+              readOnly: true
+      restartPolicy: Always
+      volumes:
+        - name: config
+          configMap:
+            name: bot-config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: instruct-lab-bot
+  name: worker-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+      app.kubernetes.io/component: worker
+      app.kubernetes.io/part-of: instruct-lab-bot
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/part-of: instruct-lab-bot
+    spec:
+      containers:
+        - env:
+            - name: ILWORKER_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: password
+          args:
+            - /instruct-lab-bot-worker
+            - --test
+            - --redis
+            - redis:6379
+            - generate
+          image: ghcr.io/instruct-lab/instruct-lab-bot/instruct-lab-serve:main
+          name: worker-test
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      restartPolicy: Always


### PR DESCRIPTION
This allows us to start thinking about K8s deployment of the bot and workers.

Some editing of the deployment.yaml is required to add secrets etc... Then:

```console
podman play kube deployment.yaml
podman play kube deployment.yaml --down
```

To make this work we also try to read the config file from multiple paths....
