### PR TITLE
Only try to get remote model name for precheck

### DIFF
--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -498,9 +498,9 @@ func (w *Worker) processJob() {
 	switch jobType {
 	case jobGenerate:
 		generateArgs := []string{"generate", "--num-instructions", fmt.Sprintf("%d", NumInstructions), "--output-dir", outputDir}
-		if TlsInsecure {
-			generateArgs = append(generateArgs, "--tls-insecure")
-		}
+		//if TlsInsecure {
+		//	generateArgs = append(generateArgs, "--tls-insecure")
+		//}
 		// TODO -- add a separate config option
 		//if EndpointURL != "" && modelName != "unknown" {
 		//	// Append the endpoint URL and model name as arguments if they are defined
@@ -853,7 +853,8 @@ func (w *Worker) determineModelName(jobType string) string {
 		return "sdg service backend"
 	}
 
-	if EndpointURL != localEndpoint {
+	// precheck is the only case we use a remote OpenAI endpoint right now
+	if EndpointURL != localEndpoint && jobType == jobPreCheck {
 		modelName, err := w.fetchModelName(false)
 		if err != nil {
 			w.logger.Errorf("Failed to fetch model name: %v", err)


### PR DESCRIPTION
In prod, the only case we want to try to get a remote model name is
under `precheck`, where we use `ilab chat` against a remote endpoint
URL.

The code for endpoint URLs under `generate-local` is commented out,
but that's because we only have a single `--endpoint-url` option. We
need to split it between `--chat-endpoint-url` and
`--generate-endpoint-url` or something like that, so we can say
specifically which endpoint to use with each command.

In the meantime though, we need to make sure we don't hit the
endpoint when we're actually running `endpoint-local`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
