### PR TITLE
Add "enable" command to enable the bot for triaging.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "files.associations": {
     "deploy/ansible/*.yml": "ansible"
-  }
+  },
+  "cSpell.words": [
+    "triagers"
+  ]
 }

--- a/gobot/config.yaml.sample
+++ b/gobot/config.yaml.sample
@@ -4,16 +4,25 @@ server:
 
 app_configuration:
   redis_hostport: "redis:6379"
+
   # Get an ID from https://smee.io/new
   # Optional. If blank, the app will not use a webhook proxy.
   webhook_proxy_url: "https://smee.io/your-smee-id"
+
   # Specify a label that must be present on a pull request before
   # bot commands are allowed to execute. If none is specified,
   # bot commands will always be allowed by anyone able to comment
   # on PRs.
-  required_labels: 
-    - "triage-ok-to-test"
+  required_labels:
+    - "skill"
     - "knowledge"
+
+  # Remove the maintainers if you are working with your local development environment
+  maintainers:
+    - "taxonomy-triagers"
+    - "taxonomy-approvers"
+    - "taxonomy-maintainers"
+    - "labrador-org-maintainers"
   # Optional. If left commented, the default bot account is @instruct-lab-bot
   # bot_username: "@instruct-lab-bot"
 

--- a/gobot/config/config.go
+++ b/gobot/config/config.go
@@ -23,6 +23,7 @@ type MyApplicationConfig struct {
 	RedisHostPort   string   `yaml:"redis_hostport"`
 	WebhookProxyURL string   `yaml:"webhook_proxy_url"`
 	RequiredLabels  []string `yaml:"required_labels,omitempty"`
+	Maintainers     []string `yaml:"maintainers,omitempty"`
 	BotUsername     string   `yaml:"bot_username,omitempty"`
 }
 

--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/google/go-github/v60/github"
+	"github.com/instruct-lab/instruct-lab-bot/gobot/util"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+)
+
+const (
+	TriageReadinessMsg = "PR is ready for evaluation."
 )
 
 type PRCommentHandler struct {
@@ -20,15 +26,19 @@ type PRCommentHandler struct {
 	RedisHostPort  string
 	RequiredLabels []string
 	BotUsername    string
+	Maintainers    []string
 }
 
 type PRComment struct {
-	repoOwner string
-	repoName  string
-	prNum     int
-	author    string
-	body      string
-	installID int64
+	repoOwner         string
+	repoName          string
+	repoOrg           string
+	prNum             int
+	author            string
+	body              string
+	installID         int64
+	sha               string
+	labels            []*github.Label
 }
 
 func (h *PRCommentHandler) Handles() []string {
@@ -50,20 +60,32 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 		return nil
 	}
 
+	h.Logger.Debugf("Details of the event: %v", event)
 	repo := event.GetRepo()
 	prComment := PRComment{
 		repoOwner: repo.GetOwner().GetLogin(),
 		repoName:  repo.GetName(),
+		repoOrg:   event.GetOrganization().GetLogin(),
 		prNum:     event.GetIssue().GetNumber(),
 		author:    event.GetComment().GetUser().GetLogin(),
 		body:      event.GetComment().GetBody(),
 		installID: githubapp.GetInstallationIDFromEvent(&event),
 	}
 
+
 	client, err := h.NewInstallationClient(prComment.installID)
 	if err != nil {
 		return err
 	}
+	// Fetch the PR sha and labels to avoid multiple Pull Request API calls
+	pr, _, err := client.PullRequests.Get(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum)
+	if err != nil {
+		h.Logger.Errorf("Failed to get pull request (%s/%s#%d) related to the issue comment: %w", prComment.repoOwner, prComment.repoName, prComment.prNum, err)
+		return err
+	}
+
+	prComment.sha = pr.GetHead().GetSHA()
+	prComment.labels = pr.Labels
 
 	words := strings.Fields(strings.TrimSpace(prComment.body))
 	if len(words) < 2 {
@@ -73,6 +95,12 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 		return nil
 	}
 	switch words[1] {
+	case "enable":
+		err = h.enableCommand(ctx, client, &prComment)
+		if err != nil {
+			h.reportError(ctx, client, &prComment, err)
+		}
+		return err
 	case "generate-local":
 		err = h.generateCommand(ctx, client, &prComment)
 		if err != nil {
@@ -97,7 +125,7 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 }
 
 func (h *PRCommentHandler) reportError(ctx context.Context, client *github.Client, prComment *PRComment, err error) {
-	h.Logger.Errorf("Error processing command on %s/%s#%d by %s: %v",
+	h.Logger.Warnf("Error processing command on %s/%s#%d by %s: %v",
 		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author, err)
 
 	msg := fmt.Sprintf("Beep, boop 🤖  Sorry, An error has occurred : %v", err)
@@ -115,15 +143,10 @@ func (h *PRCommentHandler) checkRequiredLabel(ctx context.Context, client *githu
 		return true, nil
 	}
 
-	pr, _, err := client.PullRequests.Get(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum)
-	if err != nil {
-		return false, err
-	}
-
 	labelFound := false
-	for _, label := range pr.Labels {
-		for _, required := range requiredLabels {
-			if label.GetName() == required {
+	for _, required := range requiredLabels {
+		for _, label := range prComment.labels {
+				if label.GetName() == required {
 				labelFound = true
 				break
 			}
@@ -135,7 +158,7 @@ func (h *PRCommentHandler) checkRequiredLabel(ctx context.Context, client *githu
 			requiredLabels, prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
 		missingLabelComment := fmt.Sprintf("Beep, boop 🤖: To proceed, the pull request must have one of the '%v' labels.", requiredLabels)
 		botComment := github.IssueComment{Body: &missingLabelComment}
-		_, _, err = client.Issues.CreateComment(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum, &botComment)
+		_, _, err := client.Issues.CreateComment(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum, &botComment)
 		if err != nil {
 			h.Logger.Errorf("Failed to comment on pull request about missing label: %v", err)
 		}
@@ -162,6 +185,11 @@ func (h *PRCommentHandler) queueGenerateJob(ctx context.Context, client *github.
 	}
 
 	err = setJobKey(r, jobNumber, "pr_number", prComment.prNum)
+	if err != nil {
+		return err
+	}
+
+	err = setJobKey(r, jobNumber, "pr_sha", prComment.sha)
 	if err != nil {
 		return err
 	}
@@ -200,24 +228,131 @@ func (h *PRCommentHandler) queueGenerateJob(ctx context.Context, client *github.
 	if err != nil {
 		return err
 	}
-	msg := "Beep, boop 🤖  Generating test data for your pull request.\n\n" +
+
+	msg := "Generating test data for your pull request.\n\n" +
 		"This will take several minutes...\n\n" +
 		"Your job ID is " + strconv.FormatInt(jobNumber, 10) + "."
+
+	var statusContext string
+	switch jobType {
+	case "generate":
+		statusContext = util.GenerateLocalStatus
+	case "precheck":
+		statusContext = util.PrecheckStatus
+	case "sdg-svc":
+		statusContext = util.GenerateSDGStatus
+	case "enable":
+		statusContext = util.TriageReadinessStatus
+	default:
+		h.Logger.Errorf("Unknown job type: %s", jobType)
+	}
+
+	return util.PostPullRequestStatus(ctx, client, "pending", msg, statusContext, util.InstructLabMaintainersTeamUrl, prComment.repoOwner, prComment.repoName, prComment.sha)
+
+}
+
+func (h *PRCommentHandler) checkAuthorPermission(ctx context.Context, client *github.Client, prComment *PRComment, teamName string) (bool, error) {
+	// Check if the user is a part of teams allowed to trigger the command
+
+	if prComment.repoOrg == "" {
+		h.Logger.Warnf("No organization found in the repository URL")
+	}
+
+	teamMembership, response, err := client.Teams.GetTeamMembershipBySlug(ctx, prComment.repoOrg, teamName, prComment.author)
+	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			h.Logger.Infof("User %s is not a part of the team %s : %v", prComment.author, teamName, err)
+			return false, nil
+		}
+		return false, err
+	}
+
+	h.Logger.Debugf("Team membership response for user %s: %v", prComment.author, response)
+	h.Logger.Debugf("Team membership for user %s: %v", prComment.author, teamMembership)
+
+	if teamMembership.GetState() != "active" || teamMembership.GetRole() != "maintainer" {
+		h.Logger.Infof("User %s does not have required permission in the team %s", prComment.author, teamName)
+		return false, nil
+	}
+	h.Logger.Infof("User %s is a part of the team %s", prComment.author, teamName)
+	return true, nil
+}
+
+
+func (h *PRCommentHandler) checkEnableStatus(ctx context.Context, client *github.Client, prComment *PRComment) (bool, error) {
+	repoStatus, response, err := client.Repositories.ListStatuses(ctx, prComment.repoOwner, prComment.repoName, prComment.sha, nil)
+	if err != nil {
+		h.Logger.Errorf("Failed to check repository status for %s/%s: %v", prComment.repoOwner, prComment.repoName, err.Error())
+		return false, err
+	}
+
+	h.Logger.Debugf("Repository status for %s/%s: %v", prComment.repoOwner, prComment.repoName, repoStatus)
+
+	if response.StatusCode == http.StatusOK {
+		for _, status := range repoStatus {
+			if strings.HasSuffix(status.GetURL(),prComment.sha) {
+				if status.GetState() == util.Success && status.GetContext() == util.TriageReadinessStatus{
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func (h *PRCommentHandler) enableCommand(ctx context.Context, client *github.Client, prComment *PRComment) error {
+	h.Logger.Infof("Enable command received on %s/%s#%d by author %s",
+		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
+
+	h.Logger.Infof("Maintainers: %v", h.Maintainers)
+
+	// Check if user is part of the teams that are allowed to enable the bot
+	isAllowed := true
+	for _, teamName := range h.Maintainers {
+		var err error
+		isAllowed, err = h.checkAuthorPermission(ctx, client, prComment, teamName)
+		if err != nil {
+			h.Logger.Errorf("Failed to check comment author (%s) permission for team (%s): %v", prComment.author, teamName, err.Error())
+		}
+		if isAllowed {
+			break
+		}
+	}
+
+	if !isAllowed {
+		return fmt.Errorf("User %s is not allowed to enable the instruct bot. Only %v teams are allowed to enable the bot.", prComment.author, h.Maintainers)
+	}
+
+	msg := fmt.Sprintf("Beep, boop 🤖 Hi, I'm %s and I'm going to help you"+
+		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
+	msg += fmt.Sprintf("I support the following commands:\n\n"+
+		"* `%s precheck` -- Check existing model behavior using the questions in this proposed change.\n"+
+		"* `%s generate` -- Generate a sample of synthetic data using the synthetic data generation backend infrastructure.\n"+
+		"* `%s generate-local` -- Generate a sample of synthetic data using a local model.\n",
+		h.BotUsername, h.BotUsername, h.BotUsername)
 	botComment := github.IssueComment{
 		Body: &msg,
 	}
 
 	if _, _, err := client.Issues.CreateComment(ctx, prComment.repoOwner, prComment.repoName, prComment.prNum, &botComment); err != nil {
 		h.Logger.Error("Failed to comment on pull request: %w", err)
-		return err
 	}
 
-	return nil
+	return util.PostPullRequestStatus(ctx, client, util.Success, TriageReadinessMsg, util.TriageReadinessStatus, util.InstructLabMaintainersTeamUrl, prComment.repoOwner, prComment.repoName, prComment.sha)
 }
 
 func (h *PRCommentHandler) generateCommand(ctx context.Context, client *github.Client, prComment *PRComment) error {
 	h.Logger.Infof("Generate command received on %s/%s#%d by %s",
 		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
+
+	isBotEnabled, err := h.checkEnableStatus(ctx, client, prComment)
+	if err != nil {
+		return err
+	}
+
+	if !isBotEnabled {
+		return errors.New("Bot is not enabled on this PR. Maintainers need to enable the bot first.")
+	}
 
 	present, err := h.checkRequiredLabel(ctx, client, prComment, h.RequiredLabels)
 	if !present || err != nil {
@@ -231,6 +366,15 @@ func (h *PRCommentHandler) precheckCommand(ctx context.Context, client *github.C
 	h.Logger.Infof("Precheck command received on %s/%s#%d by %s",
 		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
 
+	isBotEnabled, err := h.checkEnableStatus(ctx, client, prComment)
+	if err != nil {
+		return err
+	}
+
+	if !isBotEnabled {
+		return fmt.Errorf("Bot is not enabled on this PR. Maintainers need to enable the bot first.")
+	}
+
 	present, err := h.checkRequiredLabel(ctx, client, prComment, h.RequiredLabels)
 	if !present || err != nil {
 		return err
@@ -242,6 +386,15 @@ func (h *PRCommentHandler) precheckCommand(ctx context.Context, client *github.C
 func (h *PRCommentHandler) sdgSvcCommand(ctx context.Context, client *github.Client, prComment *PRComment) error {
 	h.Logger.Infof("SDG svc command received on %s/%s#%d by %s",
 		prComment.repoOwner, prComment.repoName, prComment.prNum, prComment.author)
+
+	isBotEnabled, err := h.checkEnableStatus(ctx, client, prComment)
+	if err != nil {
+		return err
+	}
+
+	if !isBotEnabled {
+		return fmt.Errorf("Bot is not enabled on this PR. Maintainers need to enable the bot first.")
+	}
 
 	present, err := h.checkRequiredLabel(ctx, client, prComment, h.RequiredLabels)
 	if !present || err != nil {

--- a/gobot/handlers/pull_request.go
+++ b/gobot/handlers/pull_request.go
@@ -2,12 +2,8 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	"github.com/google/go-github/v60/github"
 	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -23,44 +19,5 @@ func (h *PullRequestHandler) Handles() []string {
 }
 
 func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
-	var event github.PullRequestEvent
-	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse issue comment event payload")
-	}
-
-	if event.GetAction() != "opened" {
-		return nil
-	}
-
-	installID := githubapp.GetInstallationIDFromEvent(&event)
-	repo := event.GetRepo()
-	repoOwner := repo.GetOwner().GetLogin()
-	repoName := repo.GetName()
-	prNum := event.GetPullRequest().GetNumber()
-
-	client, err := h.NewInstallationClient(installID)
-	if err != nil {
-		return err
-	}
-	msg := fmt.Sprintf("Beep, boop 🤖 Hi, I'm %s and I'm going to help you"+
-		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
-	if len(h.RequiredLabels) > 0 {
-		msg += fmt.Sprintf("> [!NOTE]\n"+
-			"> Before you are able to use the bot's commands, it must be triaged "+
-			"and have one of the `%v` labels applied to it.\n\n", h.RequiredLabels)
-	}
-	msg += fmt.Sprintf("I support the following commands:\n\n"+
-		"* `%s precheck` -- Check existing model behavior using the questions in this proposed change.\n"+
-		"* `%s generate` -- Generate a sample of synthetic data using the synthetic data generation backend infrastructure.\n"+
-		"* `%s generate-local` -- Generate a sample of synthetic data using a local model.\n",
-		h.BotUsername, h.BotUsername, h.BotUsername)
-	botComment := github.IssueComment{
-		Body: &msg,
-	}
-
-	if _, _, err := client.Issues.CreateComment(ctx, repoOwner, repoName, prNum, &botComment); err != nil {
-		h.Logger.Error("Failed to comment on pull request: %w", err)
-	}
-
 	return nil
 }

--- a/gobot/util/pr_status.go
+++ b/gobot/util/pr_status.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"context"
+
+	"github.com/google/go-github/v60/github"
+)
+
+const (
+	Success = "success"
+	Failure = "failure"
+	Error   = "error"
+	Pending = "pending"
+	InstructLabMaintainersTeamUrl = "https://github.com/instruct-lab/community/blob/main/MAINTAINERS.md"
+	TriageReadinessStatus = "Triage Readiness Status"
+	PrecheckStatus = "Precheck Status"
+	GenerateLocalStatus = "Generate Local Status"
+	GenerateSDGStatus = "Generate SDG Status"
+
+)
+
+func PostPullRequestStatus(ctx context.Context, client *github.Client, state string, msg string, statusCtx string,
+	targetUrl string, repoOwner string, repoName string, prSha string) error {
+
+	status := &github.RepoStatus{
+		State:       github.String(state),		// Status state: success, failure, error, or pending
+		Description: github.String(msg), 		// Status description
+		Context:     github.String(statusCtx), 		// Status context
+		TargetURL:   github.String(targetUrl),		// Target URL to redirect
+	}
+
+	_, _, err := client.Repositories.CreateStatus(ctx, repoOwner, repoName, prSha, status)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This patch is the implementation of the enhancement : https://github.com/instruct-lab/enhancements/pull/11

Add "enable" command to enable the bot for triaging.
This PR changes the control flow as follows

- If maintainers didn't enable the bot on the PR using the `@instruct-lab-bot enable`, it will throw the error saying the bot needs to be enabled.
- When maintainer enable the bot, it adds status to the commit saying `Triage Readiness status` with green tick and also adds the welcome message comment.
- If any other contributors except `taxonomy-triagers`, `taxonomy-approvers`, `taxonomy-maintainers` tried
  to enable bot, it will throw an error.
- Once bot is enabled, contributors can fire `precheck` ,`generate`, `generate-local` commands. Whenever these
   commands are thrown, bot will add `pending` status for the command that is executing on the worker node.
- Once the command is done, commit status will change to `success` state and the `Details` will take contributors to the aws-s3 bucket for the results.
- If user fire any wrong command, it will throw error message.
- When user pushes any new commits to the PR, all the status are removed.

Note: Above workflow requires Read & Write permissions for "Commit Statues" for the lab bot app (also taxonomy needs to accept the permission change - it's usual process for github apps)