### PR TITLE
Revert the instruct-lab-bot repo to upstream main repo

### DIFF
--- a/deploy/ansible/worker/tasks/main.yml
+++ b/deploy/ansible/worker/tasks/main.yml
@@ -19,9 +19,8 @@
 
 - name: Clone the repository  # noqa latest[git]
   ansible.builtin.git:
-    repo: 'https://{{ github_token }}@github.com/vishnoianil/instruct-lab-bot'
+    repo: 'https://{{ github_token }}@github.com/instruct-lab/instruct-lab-bot'
     dest: "~/instruct-lab-bot"
-    version: install-worker
 
 - name: Set default args for install-worker
   ansible.builtin.set_fact:


### PR DESCRIPTION
To test install-worker.sh changes, we need to clone the local repo. But mostly you endup forgetting to revert it.