### PR TITLE
Re-enable auto builds of images on main

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -3,11 +3,10 @@ name: Publish container image
 on:
   workflow_dispatch:
 
-# Temporarily disable automated image push due to repo resource constraints until open sourced
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   push_to_registries_bot:


### PR DESCRIPTION
We turned this off when the org was hitting github actions limits.
After reviewing actions usage and costs, it seems fine to turn back
on. Our github actions costs are quite minimal compared to other
costs. The productivity improvement seems worth it.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
