### PR TITLE
Report git errors back to the PR comments

### DIFF
--- a/gobot/bot/bot.go
+++ b/gobot/bot/bot.go
@@ -173,8 +173,8 @@ func receiveResults(config *config.Config, logger *zap.SugaredLogger, cc githuba
 
 		jobDuration, err := r.Get("jobs:" + result + ":duration").Result()
 		if err != nil || jobDuration == "" {
-			logger.Errorf("No job duration time found for job %s", result)
-			continue
+			// Do not break out of the current iteration since the job could have failed without a duration
+			logger.Warnf("No job duration time found for job %s", result)
 		}
 
 		logger.Infof("Processing result for %s/%s#%s, job ID: %s, job duration: %ss ", repoOwner, repoName, prNumber, result, jobDuration)


### PR DESCRIPTION
- Moved git operations into a single method so the error reporting can get wrapped up in a single call. Also pruning down processjob.
- Fixed a bug where if a job failed, job duration being nil would break the iteration.