### PR TITLE
Added error handling and a job id PR comment for a new job

### DIFF
--- a/gobot/util/pr_errors.go
+++ b/gobot/util/pr_errors.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v60/github"
+)
+
+func PostPullRequestError(ctx context.Context, client *github.Client, params PullRequestStatusParams) error {
+	botComment := github.IssueComment{
+		Body: &params.JobErr,
+	}
+
+	// Post the job error as a new comment
+	if _, _, err := client.Issues.CreateComment(ctx, params.RepoOwner, params.RepoName, params.PrNum, &botComment); err != nil {
+		return fmt.Errorf("failed to comment the error on pull request: %w", err)
+	}
+
+	// This message is short due to limited viewable width in the status box
+	errStatusMsg := fmt.Sprintf("See bot message for error details for job id: %s", params.JobID)
+
+	status := &github.RepoStatus{
+		State:       github.String(params.State),
+		Description: github.String(errStatusMsg),
+		Context:     github.String(params.StatusCtx),
+	}
+
+	// Update the PR status to an error state
+	_, _, err := client.Repositories.CreateStatus(ctx, params.RepoOwner, params.RepoName, params.PrSha, status)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/gobot/util/pr_status.go
+++ b/gobot/util/pr_status.go
@@ -2,36 +2,60 @@ package util
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/go-github/v60/github"
 )
 
 const (
-	Success = "success"
-	Failure = "failure"
-	Error   = "error"
-	Pending = "pending"
+	Success                       = "success"
+	Failure                       = "failure"
+	Error                         = "error"
+	Pending                       = "pending"
 	InstructLabMaintainersTeamUrl = "https://github.com/instruct-lab/community/blob/main/MAINTAINERS.md"
-	TriageReadinessStatus = "Triage Readiness Status"
-	PrecheckStatus = "Precheck Status"
-	GenerateLocalStatus = "Generate Local Status"
-	GenerateSDGStatus = "Generate SDG Status"
-
+	TriageReadinessStatus         = "Triage Readiness Status"
+	PrecheckStatus                = "Precheck Status"
+	GenerateLocalStatus           = "Generate Local Status"
+	GenerateSDGStatus             = "Generate SDG Status"
 )
 
-func PostPullRequestStatus(ctx context.Context, client *github.Client, state string, msg string, statusCtx string,
-	targetUrl string, repoOwner string, repoName string, prSha string) error {
+type PullRequestStatusParams struct {
+	State      string
+	MsgStatus  string
+	StatusCtx  string
+	TargetURL  string
+	RepoOwner  string
+	RepoName   string
+	PrSha      string
+	PrNum      int
+	JobType    string
+	JobID      string
+	MsgComment string
+	JobErr     string
+}
 
-	status := &github.RepoStatus{
-		State:       github.String(state),		// Status state: success, failure, error, or pending
-		Description: github.String(msg), 		// Status description
-		Context:     github.String(statusCtx), 		// Status context
-		TargetURL:   github.String(targetUrl),		// Target URL to redirect
+func PostPullRequestStatus(ctx context.Context, client *github.Client, params PullRequestStatusParams) error {
+	// Post the job ID and job type as a new comment for the new pending job
+	if params.State == "pending" {
+		comment := &github.IssueComment{
+			Body: &params.MsgComment,
+		}
+		if _, _, err := client.Issues.CreateComment(ctx, params.RepoOwner, params.RepoName, int(params.PrNum), comment); err != nil {
+			return fmt.Errorf("failed to comment on the pending job: %w", err)
+		}
 	}
 
-	_, _, err := client.Repositories.CreateStatus(ctx, repoOwner, repoName, prSha, status)
+	status := &github.RepoStatus{
+		State:       github.String(params.State),     // Status state: success, failure, error, or pending
+		Description: github.String(params.MsgStatus), // Status description
+		Context:     github.String(params.StatusCtx), // Status context
+		TargetURL:   github.String(params.TargetURL), // Target URL to redirect
+	}
+
+	_, _, err := client.Repositories.CreateStatus(ctx, params.RepoOwner, params.RepoName, params.PrSha, status)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
- Add error handling to status. The user gets a comment with details and the status alerts there was an error with the job id for correlation to the comment.
- Add an initial comment after a trigger for a pending job with the job type and job ID. The job ID lets the user and
 us operating the service easily correlate a job to
results/logs for troubleshooting.
- Added a PullRequestStatusParams struct to encapsulate parameters to util.*
- Adjust status messages to be visible in the limited width window of the PR's status box.

Closes #170
Closes #199
Closes #186