### PR TITLE
deploy: Allow bot maintainers to enable the bot

### DIFF
--- a/deploy/ansible/gobot/templates/config.yaml.j2
+++ b/deploy/ansible/gobot/templates/config.yaml.j2
@@ -10,6 +10,7 @@ app_configuration:
     - "taxonomy-approvers"
     - "taxonomy-maintainers"
     - "labrador-org-maintainers"
+    - "instruct-lab-bot-maintainers"
   required_labels:
     - "skill"
     - "knowledge"


### PR DESCRIPTION
This is necessary for testing purposes as the bot gets updates.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
