### PR TITLE
Remove "maintainer" check from teamMembership.GetState()

### DIFF
--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -272,7 +272,7 @@ func (h *PRCommentHandler) checkAuthorPermission(ctx context.Context, client *gi
 
 	h.Logger.Debugf("Team membership for user %s: %v", prComment.author, teamMembership)
 
-	if teamMembership.GetState() != "active" || teamMembership.GetRole() != "maintainer" {
+	if teamMembership.GetState() != "active" {
 		h.Logger.Infof("User %s does not have required permission in the team %s", prComment.author, teamName)
 		return false, nil
 	}


### PR DESCRIPTION
- A triager is not necessarily a maintainer, but a member.
#231 