### PR TITLE
Add additional err logging yaml unmarshalling

### DIFF
--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -285,6 +285,8 @@ func (w *Worker) runPrecheck(lab, outputDir, modelName string) error {
 		var data map[string]interface{}
 		err = yaml.Unmarshal(content, &data)
 		if err != nil {
+			// Odd are, the PR was not yaml-linted since its invalid yaml failing an unmarshall
+			err = fmt.Errorf("the original taxonomy yaml likely did not pass yaml-linting, here is the unmarshalling error: %v", err)
 			w.logger.Error(err)
 			return err
 		}


### PR DESCRIPTION
- In this scenario the yaml passed was unable to be unmarshalled. This was prior to yaml-linting checks, so this beefs up logging to reduce confusion. Example, PR https://github.com/instruct-lab/taxonomy/pull/76
- Shoutout to @dougbtv 😻