### PR TITLE
Deploy on Kubernetes

### DIFF
--- a/deploy/instruct-lab-bot/base/bot/deployment.yaml
+++ b/deploy/instruct-lab-bot/base/bot/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bot
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/instruct-lab/instruct-lab-bot/instruct-lab-gobot:main
+          env:
+            - name: ILBOT_GITHUB_INTEGRATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: instruct-lab-bot
+                  key: ILBOT_GITHUB_INTEGRATION_ID
+            - name: ILBOT_GITHUB_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: instruct-lab-bot
+                  key: ILBOT_GITHUB_WEBHOOK_SECRET
+            - name: ILBOT_GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: instruct-lab-bot
+                  key: ILBOT_GITHUB_APP_PRIVATE_KEY
+          name: bot
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      restartPolicy: Always

--- a/deploy/instruct-lab-bot/base/bot/kustomization.yaml
+++ b/deploy/instruct-lab-bot/base/bot/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: bot
+      app.kubernetes.io/name: bot

--- a/deploy/instruct-lab-bot/base/kustomization.yaml
+++ b/deploy/instruct-lab-bot/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: instruct-lab-bot
+resources:
+  - bot
+  - redis
+  - worker
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/part-of: instruct-lab-bot

--- a/deploy/instruct-lab-bot/base/redis/kustomization.yaml
+++ b/deploy/instruct-lab-bot/base/redis/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/part-of: instruct-lab-bot

--- a/deploy/instruct-lab-bot/base/redis/service.yaml
+++ b/deploy/instruct-lab-bot/base/redis/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    statefulset: redis
+  type: ClusterIP

--- a/deploy/instruct-lab-bot/base/redis/statefulset.yaml
+++ b/deploy/instruct-lab-bot/base/redis/statefulset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      statefulset: redis
+  serviceName: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        statefulset: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:6.0
+          args:
+            [
+              "--maxmemory",
+              "200mb",
+              "--maxmemory-policy",
+              "allkeys-lru",
+              "--save",
+            ]
+          resources:
+            limits:
+              cpu: 250m
+              memory: 250Mi
+            requests:
+              cpu: 250m
+              memory: 250Mi
+          ports:
+            - containerPort: 6379
+              name: redis
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - redis-cli
+                - ping
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - redis-cli
+                - ping

--- a/deploy/instruct-lab-bot/base/worker/deployment.yaml
+++ b/deploy/instruct-lab-bot/base/worker/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - env:
+            - name: ILWORKER_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: instruct-lab-bot
+                  key: ILWORKER_GITHUB_TOKEN
+          args:
+            - /instruct-lab-bot-worker
+            - --test
+            - --redis
+            - redis:6379
+            - generate
+          image: ghcr.io/instruct-lab/instruct-lab-bot/instruct-lab-serve:main
+          name: worker
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      restartPolicy: Always

--- a/deploy/instruct-lab-bot/base/worker/kustomization.yaml
+++ b/deploy/instruct-lab-bot/base/worker/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: worker
+      app.kubernetes.io/name: worker

--- a/deploy/instruct-lab-bot/overlays/dev/kustomization.yaml
+++ b/deploy/instruct-lab-bot/overlays/dev/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: instruct-lab-bot
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: Deployment
+      name: bot
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: ILBOT_WEBHOOK_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              name: instruct-lab-bot
+              key: ILBOT_WEBHOOK_PROXY_URL

--- a/deploy/kind.yaml
+++ b/deploy/kind.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: instruct-lab-bot-dev
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  - role: worker
+    image: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+  - role: worker
+    image: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245


### PR DESCRIPTION
Adds the necessary manifests for deployment on Kubernetes.
Make target added to `run-on-kind` with podman.
Requires: #196 
Relates To: #240 