### PR TITLE
Fix confusing log entry.

### DIFF
--- a/gobot/handlers/issue_comment.go
+++ b/gobot/handlers/issue_comment.go
@@ -95,7 +95,6 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 		return nil
 	}
 	if words[0] != h.BotUsername {
-		h.Logger.Infof("Bot username %s is not found in the comment: %s", h.BotUsername, prComment.body)
 		return nil
 	}
 


### PR DESCRIPTION
It logs that bot name is not present in the comment, when bot post any update and it receives the
webhook notification for the same update, which
obviously won't have bot name in it.