### PR TITLE
Remove explicit enable command

### DIFF
--- a/gobot/cmd/root.go
+++ b/gobot/cmd/root.go
@@ -13,7 +13,6 @@ import (
 
 	gosmee "github.com/chmouel/gosmee/gosmee"
 	"github.com/go-redis/redis"
-	"github.com/google/go-github/v60/github"
 	"github.com/gregjones/httpcache"
 	"github.com/instructlab/instructlab-bot/gobot/handlers"
 	"github.com/instructlab/instructlab-bot/gobot/util"
@@ -118,6 +117,7 @@ func run(logger *zap.SugaredLogger) error {
 		Logger:         logger,
 		RequiredLabels: RequiredLabels,
 		BotUsername:    BotUsername,
+		Maintainers:    Maintainers,
 	}
 
 	webhookHandler := githubapp.NewDefaultEventDispatcher(ghConfig, prCommentHandler, prHandler)
@@ -386,24 +386,4 @@ func receiveResults(redisHostPort string, logger *zap.SugaredLogger, cc githubap
 			logger.Errorf("Failed to post comment on pr %s/%s#%d: %v", params.RepoOwner, params.RepoName, params.PrNum, err)
 		}
 	}
-}
-
-// PostComment sends a comment to the GH pull request.
-func PostComment(ctx context.Context, cc githubapp.ClientCreator, logger *zap.SugaredLogger, installIDInt int, repoOwner, repoName string, prNumInt int, commentBody string) error {
-	issueComment := github.IssueComment{
-		Body: github.String(commentBody),
-	}
-
-	client, err := cc.NewInstallationClient(int64(installIDInt))
-	if err != nil {
-		logger.Errorf("Error creating GitHub client: %v", err)
-		return err
-	}
-	_, _, err = client.Issues.CreateComment(ctx, repoOwner, repoName, prNumInt, &issueComment)
-	if err != nil {
-		logger.Errorf("Error posting comment to GitHub PR: %v", err)
-		return err
-	}
-
-	return nil
 }

--- a/gobot/handlers/pull_request.go
+++ b/gobot/handlers/pull_request.go
@@ -6,9 +6,14 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v60/github"
+	"github.com/instructlab/instructlab-bot/gobot/util"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+)
+
+const (
+	TriageReadinessMsg = "PR is ready for evaluation."
 )
 
 type PullRequestHandler struct {
@@ -16,6 +21,7 @@ type PullRequestHandler struct {
 	Logger         *zap.SugaredLogger
 	RequiredLabels []string
 	BotUsername    string
+	Maintainers    []string
 }
 
 func (h *PullRequestHandler) Handles() []string {
@@ -37,20 +43,16 @@ func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID s
 	repoOwner := repo.GetOwner().GetLogin()
 	repoName := repo.GetName()
 	prNum := event.GetPullRequest().GetNumber()
+	prSha := event.GetPullRequest().GetHead().GetSHA()
 
 	h.Logger.Infof("Checking for required labels: %v", h.RequiredLabels)
 	if len(h.RequiredLabels) == 0 {
 		return nil
 	}
 
-	labelFound := false
-	for _, required := range h.RequiredLabels {
-		for _, label := range event.GetPullRequest().Labels {
-			if label.GetName() == required {
-				labelFound = true
-				break
-			}
-		}
+	labelFound, err := util.CheckRequiredLabel(event.GetPullRequest().Labels, h.RequiredLabels)
+	if err != nil {
+		h.Logger.Errorf("Failed to check required labels: %v", err)
 	}
 
 	if !labelFound {
@@ -60,27 +62,57 @@ func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID s
 
 	client, err := h.NewInstallationClient(installID)
 	if err != nil {
+		h.Logger.Errorf("Failed to create installation client: %v", err)
 		return err
 	}
-	msg := fmt.Sprintf("Beep, boop 🤖 Hi, I'm %s and I'm going to help you"+
-		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
-	if len(h.RequiredLabels) > 0 {
-		msg += fmt.Sprintf("> [!NOTE]\n"+
-			"> Before you are able to use the bot's commands, it must be triaged "+
-			"and have one of the `%v` labels applied to it.\n\n", h.RequiredLabels)
+
+	params := util.PullRequestStatusParams{
+		CheckName: util.TriageReadinessCheck,
+		RepoOwner: repoOwner,
+		RepoName:  repoName,
+		PrNum:     prNum,
+		PrSha:     prSha,
 	}
-	msg += fmt.Sprintf("I support the following commands:\n\n"+
+
+	// Check if the triage readiness check already exists
+	enable, err := util.CheckBotEnableStatus(ctx, client, params)
+	if err != nil {
+		h.Logger.Errorf("Failed to check bot enable status: %v", err)
+		return nil
+	}
+	if enable {
+		return nil
+	}
+
+	detailsMsg := fmt.Sprintf("Beep, boop 🤖, Hi, I'm %s and I'm going to help you"+
+		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
+	detailsMsg += fmt.Sprintf("I support the following commands:\n\n"+
 		"* `%s precheck` -- Check existing model behavior using the questions in this proposed change.\n"+
 		"* `%s generate` -- Generate a sample of synthetic data using the synthetic data generation backend infrastructure.\n"+
-		"* `%s generate-local` -- Generate a sample of synthetic data using a local model.\n",
+		"* `%s generate-local` -- Generate a sample of synthetic data using a local model.\n"+
+		"> [!NOTE] \n > **Results or Errors of these commands will be posted as a pull request check in the Checks section below**\n\n",
 		h.BotUsername, h.BotUsername, h.BotUsername)
-	botComment := github.IssueComment{
-		Body: &msg,
+
+	if len(h.Maintainers) > 0 {
+		detailsMsg += fmt.Sprintf("> [!NOTE] \n > **Currently only maintainers belongs to [%v] teams are allowed to run these commands**.\n", h.Maintainers)
 	}
 
-	if _, _, err := client.Issues.CreateComment(ctx, repoOwner, repoName, prNum, &botComment); err != nil {
-		h.Logger.Error("Failed to comment on pull request: %w", err)
+	params.Status = util.CheckComplete
+	params.Conclusion = util.CheckStatusSuccess
+	params.CheckSummary = TriageReadinessMsg
+	params.CheckDetails = detailsMsg
+	params.Comment = detailsMsg
+
+	err = util.PostPullRequestComment(ctx, client, params)
+	if err != nil {
+		h.Logger.Errorf("Failed to post comment on PR %s/%s#%d: %v", params.RepoOwner, params.RepoName, params.PrNum, err)
+		return err
 	}
 
+	err = util.PostPullRequestCheck(ctx, client, params)
+	if err != nil {
+		h.Logger.Errorf("Failed to post check on PR %s/%s#%d: %v", params.RepoOwner, params.RepoName, params.PrNum, err)
+		return err
+	}
 	return nil
 }

--- a/gobot/handlers/pull_request.go
+++ b/gobot/handlers/pull_request.go
@@ -2,8 +2,12 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	"github.com/google/go-github/v60/github"
 	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -19,5 +23,64 @@ func (h *PullRequestHandler) Handles() []string {
 }
 
 func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.PullRequestEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse issue comment event payload")
+	}
+
+	if event.GetAction() != "labeled" {
+		return nil
+	}
+
+	installID := githubapp.GetInstallationIDFromEvent(&event)
+	repo := event.GetRepo()
+	repoOwner := repo.GetOwner().GetLogin()
+	repoName := repo.GetName()
+	prNum := event.GetPullRequest().GetNumber()
+
+	h.Logger.Infof("Checking for required labels: %v", h.RequiredLabels)
+	if len(h.RequiredLabels) == 0 {
+		return nil
+	}
+
+	labelFound := false
+	for _, required := range h.RequiredLabels {
+		for _, label := range event.GetPullRequest().Labels {
+			if label.GetName() == required {
+				labelFound = true
+				break
+			}
+		}
+	}
+
+	if !labelFound {
+		h.Logger.Infof("Required labels not found on PR, skipping posting welcome message #%d", prNum)
+		return nil
+	}
+
+	client, err := h.NewInstallationClient(installID)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf("Beep, boop 🤖 Hi, I'm %s and I'm going to help you"+
+		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
+	if len(h.RequiredLabels) > 0 {
+		msg += fmt.Sprintf("> [!NOTE]\n"+
+			"> Before you are able to use the bot's commands, it must be triaged "+
+			"and have one of the `%v` labels applied to it.\n\n", h.RequiredLabels)
+	}
+	msg += fmt.Sprintf("I support the following commands:\n\n"+
+		"* `%s precheck` -- Check existing model behavior using the questions in this proposed change.\n"+
+		"* `%s generate` -- Generate a sample of synthetic data using the synthetic data generation backend infrastructure.\n"+
+		"* `%s generate-local` -- Generate a sample of synthetic data using a local model.\n",
+		h.BotUsername, h.BotUsername, h.BotUsername)
+	botComment := github.IssueComment{
+		Body: &msg,
+	}
+
+	if _, _, err := client.Issues.CreateComment(ctx, repoOwner, repoName, prNum, &botComment); err != nil {
+		h.Logger.Error("Failed to comment on pull request: %w", err)
+	}
+
 	return nil
 }

--- a/gobot/util/pr_updates.go
+++ b/gobot/util/pr_updates.go
@@ -76,7 +76,7 @@ func PostPullRequestComment(ctx context.Context, client *github.Client, params P
 		Body: &params.Comment,
 	}
 	if _, _, err := client.Issues.CreateComment(ctx, params.RepoOwner, params.RepoName, int(params.PrNum), comment); err != nil {
-		return fmt.Errorf("failed to comment on the pending job: %w", err)
+		return err
 	}
 	return nil
 }

--- a/gobot/util/utils.go
+++ b/gobot/util/utils.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/go-github/v60/github"
+)
+
+func CheckBotEnableStatus(ctx context.Context, client *github.Client, params PullRequestStatusParams) (bool, error) {
+	checkStatus, response, err := client.Checks.ListCheckRunsForRef(ctx, params.RepoOwner, params.RepoName, params.PrSha, nil)
+	if err != nil {
+		return false, err
+	}
+
+	if response.StatusCode == http.StatusOK {
+		for _, status := range checkStatus.CheckRuns {
+			if status.GetHeadSHA() == params.PrSha &&
+				status.GetConclusion() == CheckStatusSuccess &&
+				status.GetName() == params.CheckName {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func CheckRequiredLabel(labels []*github.Label, requiredLabels []string) (bool, error) {
+	if len(requiredLabels) == 0 {
+		return true, nil
+	}
+
+	labelFound := false
+	for _, required := range requiredLabels {
+		for _, label := range labels {
+			if label.GetName() == required {
+				labelFound = true
+				break
+			}
+		}
+	}
+	return labelFound, nil
+}


### PR DESCRIPTION
Remove explicit enable command, only maintainer teams member will be able to run commands.

Bot will post a welcome message when required labels are set on the PR (currently set to skill and knowledge).

Our bot command name is not changed to @instructlab-bot from @instruct-lab-bot, due to renaming at the instruct lab organization level. But we do support the legacy bot username but post a deprecated warning on the PR.

Fixes #253 
Fixes #261 

This PR https://github.com/vishnoianil/taxonomy/pull/23 shows the workflow.