### PR TITLE
Use github status for checking bot readiness.

### DIFF
--- a/gobot/handlers/pull_request.go
+++ b/gobot/handlers/pull_request.go
@@ -3,17 +3,12 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/google/go-github/v60/github"
 	"github.com/instructlab/instructlab-bot/gobot/util"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-)
-
-const (
-	TriageReadinessMsg = "PR is ready for evaluation."
 )
 
 type PullRequestHandler struct {
@@ -67,15 +62,15 @@ func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID s
 	}
 
 	params := util.PullRequestStatusParams{
-		CheckName: util.TriageReadinessCheck,
+		CheckName: util.BotReadyStatus,
 		RepoOwner: repoOwner,
 		RepoName:  repoName,
 		PrNum:     prNum,
 		PrSha:     prSha,
 	}
 
-	// Check if the triage readiness check already exists
-	enable, err := util.CheckBotEnableStatus(ctx, client, params)
+	// Check if the bot readiness status already exists
+	enable, err := util.StatusExist(ctx, client, params, util.BotReadyStatus)
 	if err != nil {
 		h.Logger.Errorf("Failed to check bot enable status: %v", err)
 		return nil
@@ -84,34 +79,9 @@ func (h *PullRequestHandler) Handle(ctx context.Context, eventType, deliveryID s
 		return nil
 	}
 
-	detailsMsg := fmt.Sprintf("Beep, boop 🤖, Hi, I'm %s and I'm going to help you"+
-		" with your pull request. Thanks for you contribution! 🎉\n\n", h.BotUsername)
-	detailsMsg += fmt.Sprintf("I support the following commands:\n\n"+
-		"* `%s precheck` -- Check existing model behavior using the questions in this proposed change.\n"+
-		"* `%s generate` -- Generate a sample of synthetic data using the synthetic data generation backend infrastructure.\n"+
-		"* `%s generate-local` -- Generate a sample of synthetic data using a local model.\n"+
-		"> [!NOTE] \n > **Results or Errors of these commands will be posted as a pull request check in the Checks section below**\n\n",
-		h.BotUsername, h.BotUsername, h.BotUsername)
-
-	if len(h.Maintainers) > 0 {
-		detailsMsg += fmt.Sprintf("> [!NOTE] \n > **Currently only maintainers belongs to [%v] teams are allowed to run these commands**.\n", h.Maintainers)
-	}
-
-	params.Status = util.CheckComplete
-	params.Conclusion = util.CheckStatusSuccess
-	params.CheckSummary = TriageReadinessMsg
-	params.CheckDetails = detailsMsg
-	params.Comment = detailsMsg
-
-	err = util.PostPullRequestComment(ctx, client, params)
+	err = util.PostBotWelcomeMessage(ctx, client, repoOwner, repoName, prNum, prSha, h.BotUsername, h.Maintainers)
 	if err != nil {
-		h.Logger.Errorf("Failed to post comment on PR %s/%s#%d: %v", params.RepoOwner, params.RepoName, params.PrNum, err)
-		return err
-	}
-
-	err = util.PostPullRequestCheck(ctx, client, params)
-	if err != nil {
-		h.Logger.Errorf("Failed to post check on PR %s/%s#%d: %v", params.RepoOwner, params.RepoName, params.PrNum, err)
+		h.Logger.Errorf("Failed to post bot welcome message on PR %s/%s#%d: %v", repoOwner, repoName, prNum, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Checks are not immidiately available to fetch, but user can add multiple labels pretty fast, that can bombard the PR with multiple bot welcome message.
Status can be immidiately retried after posting,
and that's helpful in this scenario.

Also added "help" command, if user wants to dump the welcome message. We can use this command to post more helpful text to the PR.