### PR TITLE
Add serve-base image

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -96,7 +96,6 @@ jobs:
           platforms: linux/amd64
           build-args: |
             GITHUB_USER=instructlab-bot
-            GITHUB_TOKEN=${{ secrets.BOT_GITHUB_TOKEN }}
           target: serve
           push: true
           tags: ${{ steps.labserve_meta.outputs.tags }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -103,3 +103,59 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: worker/Containerfile
+
+  push_to_registries_serve_base:
+    name: Push serve base container image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          sudo apt install aptitude -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for labserve image
+        id: labserve_base_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/instructlab-serve-base
+
+      - name: Build and push serve image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            GITHUB_USER=instructlab-bot
+          target: serve
+          push: true
+          tags: ${{ steps.labserve_base_meta.outputs.tags }}
+          labels: ${{ steps.labserve_base_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: worker/Containerfile.servebase

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ worker-test-image: worker/Containerfile.test ## Build container image for a test
 	$(ECHO_PREFIX) printf "  %-12s worker/Containerfile.test\n" "[PODMAN]"
 	$(CMD_PREFIX) podman build -f worker/Containerfile.test -t ghcr.io/instructlab/instructlab-bot/instructlab-serve:main .
 
+ilabserve-base-image: worker/Containerfile.servebase ## Build container image for ilab serve
+	$(ECHO_PREFIX) printf "  %-12s worker/Containerfile.servebase\n" "[PODMAN]"
+	$(CMD_PREFIX) podman build -f worker/Containerfile.servebase -t ghcr.io/instructlab/instructlab-bot/instructlab-serve-base:main .
+
 .PHONY: gobot
 gobot: gobot/gobot ## Build gobot
 

--- a/worker/Containerfile
+++ b/worker/Containerfile
@@ -1,7 +1,6 @@
 # Stage 1: Build the worker binary
 FROM golang:1.22 as builder
 
-ARG GITHUB_TOKEN
 ENV WORK_DIR /app
 
 WORKDIR ${WORK_DIR}
@@ -15,8 +14,6 @@ RUN go build -o instructlab-bot-worker main.go && \
 
 # Stage 2: Setup the base environment with CUDA and dependencies
 FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9 as base
-
-ARG GITHUB_TOKEN
 
 # Install essential packages, SSH key configuration for ubi, and setup Python
 RUN dnf install -y python3.11 openssh git python3-pip make automake gcc gcc-c++ python3-devel && \
@@ -42,7 +39,7 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extr
 # Reinstall llama-cpp-python with CUDA support
 RUN --mount=type=ssh,id=default \
     python3.11 -m pip --no-cache-dir install --force-reinstall nvidia-cuda-nvcc-cu12 && \
-    python3.11 -m pip --no-cache-dir install git+https://${GITHUB_TOKEN}@github.com/instructlab/instructlab.git@stable && \
+    python3.11 -m pip --no-cache-dir install git+https://github.com/instructlab/instructlab.git@stable && \
     CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
 
 # Final Stage: Setup the runtime environment

--- a/worker/Containerfile.servebase
+++ b/worker/Containerfile.servebase
@@ -1,0 +1,36 @@
+# Stage 1: Build the worker binary
+FROM golang:1.22 as builder
+
+ENV WORK_DIR /app
+
+WORKDIR ${WORK_DIR}
+
+COPY . ${WORK_DIR}/instructlab-bot
+
+# Build the worker binary
+WORKDIR ${WORK_DIR}/instructlab-bot/worker
+RUN go build -o instructlab-bot-worker main.go && \
+    chmod +x instructlab-bot-worker
+
+FROM fedora:latest as base
+
+RUN dnf install -y python openssh git python3-pip make automake gcc gcc-c++ python3-devel && \
+    mkdir ~/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts && \
+    python -m ensurepip && \
+    dnf install -y gcc cmake gcc-c++ && \
+    dnf update -y && \
+    dnf clean all
+
+RUN --mount=type=ssh,id=default \
+    python -m pip --no-cache-dir install git+https://github.com/instructlab/instructlab.git@stable
+
+# Final Stage: Setup the runtime environment
+FROM base as serve
+
+# Copy the Go binary from the builder stage
+COPY --from=builder /app/instructlab-bot/worker/instructlab-bot-worker /usr/local/bin/instructlab-bot-worker
+
+VOLUME [ "/data" ]
+WORKDIR /data
+ENTRYPOINT [ "ilab", "serve" ]
+CMD ["/bin/bash"]


### PR DESCRIPTION
f0fc4ab worker/Containerfile: Drop GITHUB_TOKEN
6a0950f Add new ilab serve base image

commit f0fc4abd595ebf8a11fe91e03761cc42c4d06996
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Apr 22 18:01:40 2024 -0400

    worker/Containerfile: Drop GITHUB_TOKEN
    
    This is no longer necessary to clone the `instructlab/instructlab`
    repo.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 6a0950f33f56f192e1279d329f699ba259ed3c19
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Apr 22 18:03:05 2024 -0400

    Add new ilab serve base image
    
    Add an image that includes `ilab` but without any GPU support.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
