### PR TITLE
Fix the mime type in the s3 push

### DIFF
--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -1087,6 +1087,13 @@ func (w *Worker) handleOutputFiles(outputDir, prNumber, outDirName string) strin
 				})
 			}
 
+			var contentType string
+			if strings.HasSuffix(filename, ".json") || strings.Contains(filename, "json-viewer.html") {
+				contentType = "application/json-lines+json"
+			} else {
+				contentType = "text/plain"
+			}
+
 			// Upload the job file and add it to the publicFiles list
 			file, err := os.Open(fullPath)
 			if err != nil {
@@ -1100,7 +1107,7 @@ func (w *Worker) handleOutputFiles(outputDir, prNumber, outDirName string) strin
 				Bucket:      aws.String(S3Bucket),
 				Key:         aws.String(upKey),
 				Body:        file,
-				ContentType: aws.String("application/json-lines+json"),
+				ContentType: aws.String(contentType),
 			})
 			if err != nil {
 				sugar.Errorf("Could not upload file to S3: %v", err)

--- a/worker/cmd/templates.go
+++ b/worker/cmd/templates.go
@@ -147,7 +147,7 @@ func generateFormattedJSON(ctx context.Context, outputDir, filename string, svc 
    document.addEventListener("DOMContentLoaded", function() {
        var container = document.getElementById('json-editor');
        var options = {
-           mode: 'preview',
+           mode: 'view',
            modes: ['code', 'form', 'text', 'tree', 'view', 'preview']
        };
        var editor = new JSONEditor(container, options);


### PR DESCRIPTION
- Plain text content type set for anything that isn't a yaml-viewer or json-viewer.

Closes #291 