### PR TITLE
Fix ARM64 worker image build

### DIFF
--- a/worker/Containerfile
+++ b/worker/Containerfile
@@ -16,7 +16,7 @@ RUN go build -o instructlab-bot-worker main.go && \
 FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9 as base
 
 # Install essential packages, SSH key configuration for ubi, and setup Python
-RUN dnf install -y python3.11 openssh git python3-pip make automake gcc gcc-c++ python3-devel && \
+RUN dnf install -y python3.11 openssh git python3-pip make automake gcc gcc-c++ python3.11-devel && \
     ssh-keyscan github.com > ~/.ssh/known_hosts && \
     python3.11 -m ensurepip && \
     dnf install -y gcc && \


### PR DESCRIPTION
ubi9 defaults to python3.9-devel while we explcitly install python3.11 is why Python.h wasn't being found. Installing python3.11-devel resolves the build issue.

Closes #290 