### PR TITLE
Resolve precheck context passing

### DIFF
--- a/worker/Containerfile.servebase
+++ b/worker/Containerfile.servebase
@@ -14,7 +14,7 @@ RUN go build -o instructlab-bot-worker main.go && \
 
 FROM fedora:latest as base
 
-RUN dnf install -y python openssh git python3-pip make automake gcc gcc-c++ python3-devel && \
+RUN dnf install -y python openssh git python3-pip make automake gcc gcc-c++ python3-devel procps && \
     mkdir ~/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts && \
     python -m ensurepip && \
     dnf install -y gcc cmake gcc-c++ && \

--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -87,6 +87,7 @@ type Worker struct {
 	tlsClientKeyPath    string
 	tlsServerCaCertPath string
 	maxSeed             int
+	cmdRun              string
 }
 
 func NewJobProcessor(ctx context.Context, pool *redis.Pool, svc *s3.Client, logger *zap.SugaredLogger, job, precheckEndpoint, sdgEndpoint, tlsClientCertPath, tlsClientKeyPath, tlsServerCaCertPath string, maxSeed int) *Worker {
@@ -325,28 +326,33 @@ func (w *Worker) runPrecheck(lab, outputDir, modelName string) error {
 				continue
 			}
 
-			chatArgs := []string{"chat", "--quick-question", question}
 			context, hasContext := example["context"].(string)
+			// Slicing args breaks ilab chat for context, use Sprintf to control spacing
 			if hasContext {
-				chatArgs = append(chatArgs, "--context", context)
+				// Append the context to the question with a specific format
+				question = fmt.Sprintf("%s Answer this based on the following context: %s.", question, context)
 			}
+			commandStr := fmt.Sprintf("chat --quick-question %s", question)
 			if TlsInsecure {
-				chatArgs = append(chatArgs, "--tls-insecure")
+				commandStr += " --tls-insecure"
 			}
 			if PreCheckEndpointURL != localEndpoint && modelName != "unknown" {
-				chatArgs = append(chatArgs, "--endpoint-url", PreCheckEndpointURL, "--model", modelName)
+				commandStr += fmt.Sprintf(" --endpoint-url %s --model %s", PreCheckEndpointURL, modelName)
 			}
-
-			cmd := exec.Command(lab, chatArgs...)
+			cmdArgs := strings.Fields(commandStr)
+			cmd := exec.Command(lab, cmdArgs...)
+			w.cmdRun = cmd.String()
 			w.logger.Infof("Running the precheck command: %s", cmd.String())
+
 			cmd.Dir = workDir
 			cmd.Env = os.Environ()
-			cmd.Stderr = os.Stderr
 			var out bytes.Buffer
+			var errOut bytes.Buffer
 			cmd.Stdout = &out
+			cmd.Stderr = &errOut
 			err = cmd.Run()
 			if err != nil {
-				w.logger.Error(err)
+				w.logger.Errorf("Precheck command failed with error: %v; stderr: %s", err, errOut.String())
 				continue
 			}
 
@@ -756,6 +762,10 @@ func (w *Worker) postJobResults(URL, jobType string) {
 
 	if _, err := conn.Do("SET", fmt.Sprintf("jobs:%s:s3_url", w.job), URL); err != nil {
 		w.logger.Errorf("Could not set s3_url in redis: %v", err)
+	}
+
+	if _, err := conn.Do("SET", fmt.Sprintf("jobs:%s:cmd", w.job), w.cmdRun); err != nil {
+		w.logger.Errorf("Could not set cmd in redis: %v", err)
 	}
 
 	modelName := w.determineModelName(jobType)


### PR DESCRIPTION
- Fixed context argument handling in CLI tool by constructing command with `fmt.Sprintf` instead of arg slicing.
- There is probably a bug in upstream on this since other arguments don't require bypassing the Go cmd slice pattern. `--quick-question` works fine with slice construction but `--context` does not.
- Output from a job with the page showing context in the answer: https://brent-instruct-lab-dev.s3.us-east-1.amazonaws.com/precheck-pr-11-6c08042b81fc7e41d3d69f3f115c4569ca03ac8d-job-4/index.html
- Here is the logging use to generate output in the s3 bucket above. Note, we should probably visit how to better the output to be more detailed and complete:

```text
2024-05-02T03:23:43.835Z	INFO	cmd/generate.go:342	Running the precheck command: /usr/local/bin/ilab chat --quick-question can you solve the following riddle? Two turkeys in front of the turkey, two turkeys behind the turkey, tell me how many total turkeys? --context Form HOTDOGS HAMBURGERS PANCAKES --tls-insecure --endpoint-url https://merlinite-7b-vllm-openai.apps.fmaas-backend.fmaas.res.ibm.com/v1 --model /shared_model_storage/transformers_cache/models--ibm--merlinite-7b/snapshots/233d12759d5bb9344231dafdb51310ec19d79c0e
2024-05-02T03:23:49.463Z	INFO	cmd/generate.go:342	Running the precheck command: /usr/local/bin/ilab chat --quick-question question-2 can you solve the following riddle? Two turkeys in front of the turkey, two turkeys behind the turkey, tell me how many total turkeys? --context HOTDOGS HAMBURGERS PANCAKES HOTDOGS --tls-insecure --endpoint-url https://merlinite-7b-vllm-openai.apps.fmaas-backend.fmaas.res.ibm.com/v1 --model /shared_model_storage/transformers_cache/models--ibm--merlinite-7b/snapshots/233d12759d5bb9344231dafdb51310ec19d79c0e
2024-05-02T03:23:54.234Z	INFO	cmd/generate.go:342	Running the precheck command: /usr/local/bin/ilab chat --quick-question question-3 can you solve the following riddle? Two turkeys in front of the turkey, two turkeys behind the turkey, tell me how many total turkeys? --context HOTDOGS HAMBURGERS PANCAKES HOTDOGS --tls-insecure --endpoint-url https://merlinite-7b-vllm-openai.apps.fmaas-backend.fmaas.res.ibm.com/v1 --model /shared_model_storage/transformers_cache/models--ibm--merlinite-7b/snapshots/233d12759d5bb9344231dafdb51310ec19d79c0e
2024-05-02T03:24:00.355Z	INFO	cmd/generate.go:342	Running the precheck command: /usr/local/bin/ilab chat --quick-question question-4 can you solve the following riddle? Two turkeys in front of the turkey, two turkeys behind the turkey, tell me how many total turkeys? --context HOTDOGS HAMBURGERS PANCAKES HOTDOGS --tls-insecure --endpoint-url https://merlinite-7b-vllm-openai.apps.fmaas-backend.fmaas.res.ibm.com/v1 --model /shared_model_storage/transformers_cache/models--ibm--merlinite-7b/snapshots/233d12759d5bb9344231dafdb51310ec19d79c0e
2024-05-02T03:24:08.244Z	INFO	cmd/generate.go:342	Running the precheck command: /usr/local/bin/ilab chat --quick-question question-5 can you solve the following riddle? Two turkeys in front of the turkey, two turkeys behind the turkey, tell me how many total turkeys? --context HOTDOGS HAMBURGERS PANCAKES HOTDOGS --tls-insecure --endpoint-url https://merlinite-7b-vllm-openai.apps.fmaas-backend.fmaas.res.ibm.com/v1 --model /shared_model_storage/transformers_cache/models--ibm--merlinite-7b/snapshots/233d12759d5bb9344231dafdb51310ec19d79c0e
```

- Also added ps to the worker image.

Closes #306