### PR TITLE
Escape hypens in seed questions

### DIFF
--- a/worker/cmd/generate.go
+++ b/worker/cmd/generate.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -415,6 +416,10 @@ func (w *Worker) runPrecheck(lab, outputDir, modelName string) error {
 
 			context, hasContext := example["context"].(string)
 			originalQuestion := question
+
+			// Escape sequences of two or more hyphens in the question to avoid ilab seeing a flag request
+			question = escapeHyphens(question)
+
 			// Slicing args breaks ilab chat for context, use Sprintf to control spacing
 			if hasContext {
 				// Append the context to the question with a specific format
@@ -1212,6 +1217,14 @@ func (w *Worker) handleOutputFiles(outputDir, prNumber, outDirName string) strin
 	}
 
 	return indexUpKey
+}
+
+// escapeHyphens escapes sequences of two or more hyphens in the input string.
+func escapeHyphens(input string) string {
+	re := regexp.MustCompile(`-{2,}`)
+	return re.ReplaceAllStringFunc(input, func(match string) string {
+		return strings.Repeat(`\-`, len(match))
+	})
 }
 
 /* Uncomment to bypass ilab diff (temporary until upstream files are validated prior to merge)


### PR DESCRIPTION
- Tables were getting flagged as parameter flags by ilab if there was a space between the | and the ---
- This escapes hypens if two or more are in a row.
- e.g.  `| ----- |` is transformed to `| \-\-\-\- |`

Closes #385